### PR TITLE
Bump stm32f7 crate to v0.8.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ as-slice = "0.1.0"
 cortex-m = "0.6.0"
 cortex-m-rt = "0.6.8"
 nb = "0.1.2"
-stm32f7 = "0.7.1"
+stm32f7 = "0.8.0"
 
 [dependencies.bare-metal]
 version = "0.2.4"

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -735,22 +735,22 @@ pub trait SupportedWordSize: private::Sealed + Unpin + 'static {
 impl private::Sealed for u8 {}
 impl SupportedWordSize for u8 {
     fn msize() -> cr::MSIZEW {
-        cr::MSIZEW::BYTE
+        cr::MSIZEW::BITS8
     }
 
     fn psize() -> cr::PSIZEW {
-        cr::MSIZEW::BYTE
+        cr::MSIZEW::BITS8
     }
 }
 
 impl private::Sealed for u16 {}
 impl SupportedWordSize for u16 {
     fn msize() -> cr::MSIZEW {
-        cr::MSIZEW::HALFWORD
+        cr::MSIZEW::BITS16
     }
 
     fn psize() -> cr::PSIZEW {
-        cr::MSIZEW::HALFWORD
+        cr::MSIZEW::BITS16
     }
 }
 


### PR DESCRIPTION
Self-explanatory, very minor changes needed, but now the crate examples I'm trying to compile actually work and/or `panic` at different spots now :).