### PR TITLE
Fix set_open_drain for alternate mode gpios

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -414,7 +414,7 @@ macro_rules! gpio {
                         let offset = $i;
                         unsafe {
                             &(*$GPIOX::ptr()).otyper.modify(|r, w| {
-                                w.bits(r.bits() & (1 << offset))
+                                w.bits(r.bits() | (1 << offset))
                          })};
 
                         self


### PR DESCRIPTION
`set_open_drain` used the `&` operator instead of the correct `|` operator. The corrected code matches the behavior of `into_open_drain_output`.