### PR TITLE
Add support for STM32F730

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ as-slice = "0.1.0"
 cortex-m = "0.6.0"
 cortex-m-rt = "0.6.8"
 nb = "0.1.2"
-stm32f7 = "0.9.0"
+stm32f7 = "0.11.0"
 micromath = "1.0.0"
 
 [dependencies.bare-metal]
@@ -51,6 +51,7 @@ ltdc = []
 rt = ["stm32f7/rt"]
 stm32f722 = ["stm32f7/stm32f7x2", "device-selected"]
 stm32f723 = ["stm32f7/stm32f7x3", "device-selected"]
+stm32f730 = ["stm32f7/stm32f730", "device-selected"]
 stm32f732 = ["stm32f7/stm32f7x2", "device-selected"]
 stm32f733 = ["stm32f7/stm32f7x3", "device-selected"]
 stm32f745 = ["stm32f7/stm32f745", "device-selected","dma-support"]

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -674,6 +674,7 @@ macro_rules! gpio {
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -708,6 +709,7 @@ gpio!(GPIOA, gpioa, gpioaen, PA, 0, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -742,6 +744,7 @@ gpio!(GPIOB, gpiob, gpioben, PB, 1, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -776,6 +779,7 @@ gpio!(GPIOC, gpioc, gpiocen, PC, 2, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -810,6 +814,7 @@ gpio!(GPIOD, gpiod, gpioden, pd, 3, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -844,6 +849,7 @@ gpio!(GPIOE, gpioe, gpioeen, PE, 4, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -878,6 +884,7 @@ gpio!(GPIOF, gpiof, gpiofen, PF, 5, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -912,6 +919,7 @@ gpio!(GPIOG, gpiog, gpiogen, PG, 6,[
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",
@@ -946,6 +954,7 @@ gpio!(GPIOH, gpioh, gpiohen, PH, 7, [
 #[cfg(any(
     feature = "stm32f722",
     feature = "stm32f723",
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733",
     feature = "stm32f745",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ compile_error!(
     "This crate requires one of the following device features enabled:
         stm32f722
         stm32f723
+        stm32f730
         stm32f732
         stm32f733
         stm32f745
@@ -29,6 +30,9 @@ pub use stm32f7::stm32f7x2 as device;
 
 #[cfg(feature = "stm32f723")]
 pub use stm32f7::stm32f7x3 as device;
+
+#[cfg(feature = "stm32f730")]
+pub use stm32f7::stm32f730 as device;
 
 #[cfg(feature = "stm32f732")]
 pub use stm32f7::stm32f7x2 as device;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -683,6 +683,7 @@ bus! {
 #[cfg(not(any(
     feature = "stm32f722", 
     feature = "stm32f723", 
+    feature = "stm32f730",
     feature = "stm32f732",
     feature = "stm32f733"
 )))]


### PR DESCRIPTION
This PR adds support for the STM32F730. I did test the `blinky` example on real hardware and everything seems to work as expected, but I haven't tested any other peripherals yet.

Because the controller wasn't supported by the `stm32f7` crate version 0.9.0 I had to bump the dependency to the current version 0.11.0.