### PR TITLE
Use delay_us from stm32f4xx-hal crate

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -47,17 +47,29 @@ impl DelayMs<u8> for Delay {
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
-        let rvr = us * (self.clocks.hclk().0 / 8_000_000);
+        // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
+        const MAX_RVR: u32 = 0x00FF_FFFF;
 
-        assert!(rvr < (1 << 24));
+        let mut total_rvr = us * (self.clocks.hclk().0 / 8_000_000);
 
-        self.syst.set_reload(rvr);
-        self.syst.clear_current();
-        self.syst.enable_counter();
+        while total_rvr != 0 {
+            let current_rvr = if total_rvr <= MAX_RVR {
+                total_rvr
+            } else {
+                MAX_RVR
+            };
 
-        while !self.syst.has_wrapped() {}
+            self.syst.set_reload(current_rvr);
+            self.syst.clear_current();
+            self.syst.enable_counter();
 
-        self.syst.disable_counter();
+            // Update the tracking variable while we are waiting...
+            total_rvr -= current_rvr;
+
+            while !self.syst.has_wrapped() {}
+
+            self.syst.disable_counter();
+        }
     }
 }
 


### PR DESCRIPTION
This PR replaces the current `delay_us` implementation with the one from the `stm32f4xx-hal` crate. The old implementation caused a panic when the value for `us` was too large. The updated implementation doesn't panic and starts the timer multiple times if necessary to achieve the desired delay.