### PR TITLE
Add configuration to RCC PLL Q output with 48 MHz Mode

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -352,7 +352,7 @@ impl CFGR {
             let pllq = (vco_in * plln + 47_999_999) / 48_000_000;
             pll48clk = Some(Hertz(vco_in * plln / pllq));
 
-            unsafe { &*RCC::ptr() }.pllcfgr.write(|w| unsafe {
+            rcc.pllcfgr.write(|w| unsafe {
                 w.pllm().bits(pllm as u8);
                 w.plln().bits(plln as u16);
                 w.pllp().bits(pllp as u8);

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -329,8 +329,9 @@ impl CFGR {
             let vco_in = sysclk / pllm;
             assert!(vco_in >= 1_000_000 && vco_in <= 2_000_000);
 
-            // Main scaler, must result in >= 100MHz (>= 192MHz for F401)
-            // and <= 432MHz, min 50, max 432
+            // PLLN, main scaler, must result in >= 100MHz and <= 432MHz, min
+            // 50, max 432, this constraint is allways respected when vco_clkin
+            // <= 2 MHz
             let plln = if self.pll48clk {
                 // try the different valid pllq according to the valid
                 // main scaller values, and take the best

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -311,6 +311,9 @@ impl CFGR {
             let pllm_max = sysclk / 1_000_000;
 
             let target_freq = if self.pll48clk {
+                // set source clock for 48 MHz to main PLL
+                rcc.dckcfgr2.modify(|_, w| w.ck48msel().bit(false));
+
                 48_000_000
             } else {
                 sysclk * sysclk_div


### PR DESCRIPTION
Changed RCC PLL configuration: Adding PLL Q output configuration for support 48 MHz Mode - needed by USB block.