### PR TITLE
Add format checking for ci-builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+before_script:
+  - rustup component add rustfmt
 rust:
   - stable
   - nightly
@@ -26,6 +28,7 @@ script:
   - rustup target add thumbv7em-none-eabihf
   - cargo build --features=$MCU --verbose
   - cargo build --features=$MCU --release --verbose
+  - cargo fmt --all -- --check
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Try to add rust fmt command run for success builds.
Follows by #49 issue.