### PR TITLE
Fix clock setup code

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -271,14 +271,12 @@ impl CFGR {
         // Switch to HSI
         rcc.cfgr.modify(|_, w| w.sw().hsi());
 
-        // If HSE is provided by the user
-        let hse_freq: u32 = self.hse.as_ref().map_or(0, |c| c.freq);
-        // SYSCLK, must be <= 216 Mhz. By default, HSI frequency is chosen
-        let mut sysclk = self.sysclk.unwrap_or(HSI);
-        let base_clk = match hse_freq {
-            0 => HSI,
-            _ => hse_freq,
+        let base_clk = match self.hse.as_ref() {
+            Some(hse) => hse.freq,
+            None => HSI,
         };
+        // SYSCLK, must be <= 216 Mhz. By default, HSI/HSE frequency is chosen
+        let mut sysclk = self.sysclk.unwrap_or(base_clk);
 
         // Configure HSE if provided
         if self.hse.is_some() {

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -263,6 +263,14 @@ impl CFGR {
         let flash = unsafe { &(*FLASH::ptr()) };
         let rcc = unsafe { &(*RCC::ptr()) };
 
+        // Switch to fail-safe clock settings.
+        // This is useful when booting from a bootloader that alters clock tree configuration.
+        // Turn on HSI
+        rcc.cr.modify(|_, w| w.hsion().set_bit());
+        while rcc.cr.read().hsirdy().bit_is_clear() {}
+        // Switch to HSI
+        rcc.cfgr.modify(|_, w| w.sw().hsi());
+
         // If HSE is provided by the user
         let hse_freq: u32 = self.hse.as_ref().map_or(0, |c| c.freq);
         // SYSCLK, must be <= 216 Mhz. By default, HSI frequency is chosen

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -303,9 +303,9 @@ impl CFGR {
             let vco_clkin_mhz = (base_clk as f32 / pllm as f32) / 1_000_000.0;
             let mut sysclk_mhz: f32 = sysclk as f32 / 1_000_000.0;
 
-            // PLLN, main scaler, must result in >= 192MHz and <= 432MHz, min
-            // 50, max 432, this constraint is allways respected when vco_clkin
-            // <= 2 MHz
+            // PLLN, main scaler, must result in VCO frequency >=100MHz and <=432MHz,
+            // PLLN min 50, max 432, this constraint is always respected when
+            // vco_clkin <= 2 MHz
             let mut plln: f32 = 100.0;
             let allowed_pllp: [u8; 4] = [2, 4, 6, 8];
             let pllp_val = *allowed_pllp
@@ -314,7 +314,12 @@ impl CFGR {
                     plln = ((sysclk_mhz * (*pllp as f32)) / vco_clkin_mhz).floor();
                     let error = sysclk_mhz - ((plln / (*pllp as f32)) * vco_clkin_mhz);
 
-                    if error < 0.0 || plln * vco_clkin_mhz > 432.0 || plln > 432.0 || plln < 100.0 {
+                    if error < 0.0
+                        || plln * vco_clkin_mhz < 100.0
+                        || plln * vco_clkin_mhz > 432.0
+                        || plln < 50.0
+                        || plln > 432.0
+                    {
                         core::u32::MAX
                     } else {
                         (error * 1_000.0) as u32


### PR DESCRIPTION
According to the STM32F723ZE datasheet, minimal VCO output frequency is 100MHz (not 192MHz).
According to the RM0431 reference manual, 50 ≤ PLLN ≤ 432.