### PR TITLE
Add FMC via stm32-fmc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ nb = "0.1.2"
 stm32f7 = "0.11.0"
 micromath = "1.0.0"
 synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
-stm32-fmc = { version = "0.1.2", features = ["sdram"], optional = true }
+stm32-fmc = { version = "0.2.0", features = ["sdram"], optional = true }
 
 [dependencies.bare-metal]
 version = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ nb = "0.1.2"
 stm32f7 = "0.11.0"
 micromath = "1.0.0"
 synopsys-usb-otg = { version = "0.2.0", features = ["cortex-m"], optional = true }
+stm32-fmc = { version = "0.1.2", features = ["sdram"], optional = true }
 
 [dependencies.bare-metal]
 version = "0.2.4"
@@ -50,21 +51,22 @@ usbd-serial = "0.1.0"
 [features]
 device-selected = []
 ltdc = []
+fmc = ["stm32-fmc"]
 rt = ["stm32f7/rt"]
 stm32f722 = ["stm32f7/stm32f7x2", "device-selected"]
 stm32f723 = ["stm32f7/stm32f7x3", "device-selected"]
 stm32f730 = ["stm32f7/stm32f730", "device-selected"]
 stm32f732 = ["stm32f7/stm32f7x2", "device-selected"]
 stm32f733 = ["stm32f7/stm32f7x3", "device-selected"]
-stm32f745 = ["stm32f7/stm32f745", "device-selected"]
-stm32f746 = ["stm32f7/stm32f7x6", "device-selected", "ltdc"]
-stm32f756 = ["stm32f7/stm32f7x6", "device-selected", "ltdc"]
-stm32f765 = ["stm32f7/stm32f765", "device-selected"]
-stm32f767 = ["stm32f7/stm32f7x7", "device-selected", "ltdc"]
-stm32f769 = ["stm32f7/stm32f7x9", "device-selected", "ltdc"]
-stm32f777 = ["stm32f7/stm32f7x7", "device-selected", "ltdc"]
-stm32f778 = ["stm32f7/stm32f7x9", "device-selected", "ltdc"]
-stm32f779 = ["stm32f7/stm32f7x9", "device-selected", "ltdc"]
+stm32f745 = ["stm32f7/stm32f745", "device-selected", "fmc"]
+stm32f746 = ["stm32f7/stm32f7x6", "device-selected", "ltdc", "fmc"]
+stm32f756 = ["stm32f7/stm32f7x6", "device-selected", "ltdc", "fmc"]
+stm32f765 = ["stm32f7/stm32f765", "device-selected", "fmc"]
+stm32f767 = ["stm32f7/stm32f7x7", "device-selected", "ltdc", "fmc"]
+stm32f769 = ["stm32f7/stm32f7x9", "device-selected", "ltdc", "fmc"]
+stm32f777 = ["stm32f7/stm32f7x7", "device-selected", "ltdc", "fmc"]
+stm32f778 = ["stm32f7/stm32f7x9", "device-selected", "ltdc", "fmc"]
+stm32f779 = ["stm32f7/stm32f7x9", "device-selected", "ltdc", "fmc"]
 
 usb_fs = ["synopsys-usb-otg", "synopsys-usb-otg/fs"]
 
@@ -88,6 +90,10 @@ required-features = ["stm32f746", "rt"]
 [[example]]
 name = "flash"
 required-features = ["stm32f746", "rt"]
+
+[[example]]
+name = "fmc"
+required-features = ["stm32f746", "rt", "fmc"]
 
 [[example]]
 name = "hello"

--- a/examples/fmc.rs
+++ b/examples/fmc.rs
@@ -1,0 +1,100 @@
+//! Initialises FMC controller
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use core::{mem, slice};
+use stm32f7xx_hal as hal;
+
+use crate::hal::gpio::Speed;
+use crate::hal::{delay::Delay, pac, prelude::*};
+use cortex_m_rt::entry;
+
+use stm32_fmc::devices::is42s32800g_6;
+
+/// Configure pins for the FMC controller
+macro_rules! fmc_pins {
+    ($($pin:expr),*) => {
+        (
+            $(
+                $pin.into_push_pull_output()
+                    .set_speed(Speed::VeryHigh)
+                    .into_alternate_af12()
+                    .internal_pull_up(true)
+            ),*
+        )
+    };
+}
+
+#[entry]
+fn main() -> ! {
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+    let clocks = rcc.cfgr.freeze();
+
+    // Get the delay provider.
+    let mut delay = Delay::new(cp.SYST, clocks);
+
+    // IO
+    let gpiod = dp.GPIOD.split();
+    let gpioe = dp.GPIOE.split();
+    let gpiof = dp.GPIOF.split();
+    let gpiog = dp.GPIOG.split();
+    let gpioh = dp.GPIOH.split();
+    let gpioi = dp.GPIOI.split();
+
+    // Initialise SDRAM...
+    let fmc_io = fmc_pins! {
+        // A0-A11
+        gpiof.pf0, gpiof.pf1, gpiof.pf2, gpiof.pf3,
+        gpiof.pf4, gpiof.pf5, gpiof.pf12, gpiof.pf13,
+        gpiof.pf14, gpiof.pf15, gpiog.pg0, gpiog.pg1,
+        // BA0-BA1
+        gpiog.pg4, gpiog.pg5,
+        // D0-D31
+        gpiod.pd14, gpiod.pd15, gpiod.pd0, gpiod.pd1,
+        gpioe.pe7, gpioe.pe8, gpioe.pe9, gpioe.pe10,
+        gpioe.pe11, gpioe.pe12, gpioe.pe13, gpioe.pe14,
+        gpioe.pe15, gpiod.pd8, gpiod.pd9, gpiod.pd10,
+        gpioh.ph8, gpioh.ph9, gpioh.ph10, gpioh.ph11,
+        gpioh.ph12, gpioh.ph13, gpioh.ph14, gpioh.ph15,
+        gpioi.pi0, gpioi.pi1, gpioi.pi2, gpioi.pi3,
+        gpioi.pi6, gpioi.pi7, gpioi.pi9, gpioi.pi10,
+        // NBL0 - NBL3
+        gpioe.pe0, gpioe.pe1, gpioi.pi4, gpioi.pi5,
+        gpioh.ph7,              // SDCKE1
+        gpiog.pg8,              // SDCLK
+        gpiog.pg15,             // SDNCAS
+        gpioh.ph6,              // SDNE1 (!CS)
+        gpiof.pf11,             // SDRAS
+        gpioh.ph5               // SDNWE
+    };
+
+    // New SDRAM
+    let mut sdram = dp.FMC.sdram(fmc_io, is42s32800g_6::Is42s32800g {}, &clocks);
+
+    // Initialise controller and SDRAM
+    let ram = unsafe {
+        let ram_ptr: *mut u32 = sdram.init(&mut delay);
+        let ram_size_bytes = 32 * 1024 * 1024;
+
+        // Configure MPU if required
+
+        slice::from_raw_parts_mut(ram_ptr, ram_size_bytes / mem::size_of::<u32>())
+    };
+
+    // ----------------------------------------------------------
+    // Main application loop
+    let len = 8 * 1024 * 1024;
+
+    for a in 0..len {
+        ram[a] = a as u32;
+    }
+
+    loop {}
+}

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -2,7 +2,7 @@
 
 // From stm32_fmc
 use stm32_fmc::FmcPeripheral;
-use stm32_fmc::{PinsSdram, Sdram, SdramChip, SdramPinSet, SdramTargetBank};
+use stm32_fmc::{AddressPinSet, PinsSdram, Sdram, SdramChip, SdramPinSet, SdramTargetBank};
 
 use crate::pac as stm32;
 use crate::rcc::Clocks;
@@ -72,7 +72,12 @@ pub trait FmcExt: Sized {
     fn fmc(self, clocks: &Clocks) -> FMC;
 
     /// A new SDRAM memory via the Flexible Memory Controller
-    fn sdram<BANK: SdramPinSet, PINS: PinsSdram<BANK>, CHIP: SdramChip>(
+    fn sdram<
+        BANK: SdramPinSet,
+        ADDR: AddressPinSet,
+        PINS: PinsSdram<BANK, ADDR>,
+        CHIP: SdramChip,
+    >(
         self,
         pins: PINS,
         chip: CHIP,

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -1,0 +1,486 @@
+//! HAL for Flexible memory controller (FMC)
+
+// From stm32_fmc
+use stm32_fmc::FmcPeripheral;
+use stm32_fmc::{PinsSdram, Sdram, SdramChip, SdramPinSet, SdramTargetBank};
+
+use crate::pac as stm32;
+use crate::rcc::Clocks;
+use crate::time::Hertz;
+
+use crate::gpio::gpioa::PA7;
+use crate::gpio::gpiob::{PB5, PB6, PB7};
+use crate::gpio::gpioc::{PC0, PC2, PC3, PC4, PC5};
+#[cfg(any(
+    feature = "stm32f765",
+    feature = "stm32f767",
+    feature = "stm32f769",
+    feature = "stm32f777",
+    feature = "stm32f778",
+    feature = "stm32f779"
+))]
+use crate::gpio::gpioc::{PC6, PC7, PC8};
+use crate::gpio::gpiod::{
+    PD0, PD1, PD10, PD11, PD12, PD13, PD14, PD15, PD3, PD4, PD5, PD6, PD7, PD8, PD9,
+};
+use crate::gpio::gpioe::{
+    PE0, PE1, PE10, PE11, PE12, PE13, PE14, PE15, PE2, PE3, PE4, PE5, PE6, PE7, PE8, PE9,
+};
+use crate::gpio::gpiof::{PF0, PF1, PF11, PF12, PF13, PF14, PF15, PF2, PF3, PF4, PF5};
+#[cfg(any(
+    feature = "stm32f722",
+    feature = "stm32f723",
+    feature = "stm32f730",
+    feature = "stm32f732",
+    feature = "stm32f733"
+))]
+use crate::gpio::gpiog::PG11;
+#[cfg(any(
+    feature = "stm32f765",
+    feature = "stm32f767",
+    feature = "stm32f769",
+    feature = "stm32f777",
+    feature = "stm32f778",
+    feature = "stm32f779"
+))]
+use crate::gpio::gpiog::PG6;
+use crate::gpio::gpiog::{
+    PG0, PG1, PG10, PG12, PG13, PG14, PG15, PG2, PG3, PG4, PG5, PG7, PG8, PG9,
+};
+use crate::gpio::gpioh::{PH10, PH11, PH12, PH13, PH14, PH15, PH2, PH3, PH5, PH6, PH7, PH8, PH9};
+use crate::gpio::gpioi::{PI0, PI1, PI10, PI2, PI3, PI4, PI5, PI6, PI7, PI9};
+
+#[cfg(any(
+    feature = "stm32f765",
+    feature = "stm32f767",
+    feature = "stm32f769",
+    feature = "stm32f777",
+    feature = "stm32f778",
+    feature = "stm32f779"
+))]
+use crate::gpio::AF9;
+use crate::gpio::{Alternate, AF12};
+
+/// Storage type for Flexible Memory Controller and its clocks
+pub struct FMC {
+    _fmc: stm32::FMC,
+    hclk: Hertz,
+}
+
+/// Extension trait for FMC controller
+pub trait FmcExt: Sized {
+    fn fmc(self, clocks: &Clocks) -> FMC;
+
+    /// A new SDRAM memory via the Flexible Memory Controller
+    fn sdram<BANK: SdramPinSet, PINS: PinsSdram<BANK>, CHIP: SdramChip>(
+        self,
+        pins: PINS,
+        chip: CHIP,
+        clocks: &Clocks,
+    ) -> Sdram<FMC, CHIP> {
+        let fmc = self.fmc(clocks);
+        Sdram::new(fmc, pins, chip)
+    }
+
+    /// A new SDRAM memory via the Flexible Memory Controller
+    fn sdram_unchecked<CHIP: SdramChip, BANK: Into<SdramTargetBank>>(
+        self,
+        bank: BANK,
+        chip: CHIP,
+        clocks: &Clocks,
+    ) -> Sdram<FMC, CHIP> {
+        let fmc = self.fmc(clocks);
+        Sdram::new_unchecked(fmc, bank, chip)
+    }
+}
+
+impl FmcExt for stm32::FMC {
+    /// New FMC instance
+    fn fmc(self, clocks: &Clocks) -> FMC {
+        FMC {
+            _fmc: self,
+            hclk: clocks.hclk(),
+        }
+    }
+}
+
+unsafe impl FmcPeripheral for FMC {
+    const REGISTERS: *const () = stm32::FMC::ptr() as *const ();
+
+    fn enable(&mut self) {
+        // TODO : change it to something safe ...
+        let rcc = unsafe { &(*stm32::RCC::ptr()) };
+
+        // Enable FMC
+        rcc.ahb3enr.modify(|_, w| w.fmcen().enabled());
+        // Reset FMC
+        rcc.ahb3rstr.modify(|_, w| w.fmcrst().reset());
+        rcc.ahb3rstr.modify(|_, w| w.fmcrst().clear_bit());
+    }
+
+    fn source_clock_hz(&self) -> u32 {
+        // FMC block is clocked by HCLK
+        self.hclk.0
+    }
+}
+
+macro_rules! pins {
+    (FMC: $($pin:ident: [$($( #[ $pmeta:meta ] )* $inst:ty$(,)*)*])+) => {
+        $(
+            $(
+                $( #[ $pmeta ] )*
+                impl stm32_fmc::$pin for $inst {}
+            )*
+        )+
+    }
+}
+
+pins! {
+    FMC:
+        A0: [
+            PF0<Alternate<AF12>>
+        ]
+        A1: [
+            PF1<Alternate<AF12>>
+        ]
+        A10: [
+            PG0<Alternate<AF12>>
+        ]
+        A11: [
+            PG1<Alternate<AF12>>
+        ]
+        A12: [
+            PG2<Alternate<AF12>>
+        ]
+        A13: [
+            PG3<Alternate<AF12>>
+        ]
+        A14: [
+            PG4<Alternate<AF12>>
+        ]
+        A15: [
+            PG5<Alternate<AF12>>
+        ]
+        A16: [
+            PD11<Alternate<AF12>>
+        ]
+        A17: [
+            PD12<Alternate<AF12>>
+        ]
+        A18: [
+            PD13<Alternate<AF12>>
+        ]
+        A19: [
+            PE3<Alternate<AF12>>
+        ]
+        A2: [
+            PF2<Alternate<AF12>>
+        ]
+        A20: [
+            PE4<Alternate<AF12>>
+        ]
+        A21: [
+            PE5<Alternate<AF12>>
+        ]
+        A22: [
+            PE6<Alternate<AF12>>
+        ]
+        A23: [
+            PE2<Alternate<AF12>>
+        ]
+        A24: [
+            PG13<Alternate<AF12>>
+        ]
+        A25: [
+            PG14<Alternate<AF12>>
+        ]
+        A3: [
+            PF3<Alternate<AF12>>
+        ]
+        A4: [
+            PF4<Alternate<AF12>>
+        ]
+        A5: [
+            PF5<Alternate<AF12>>
+        ]
+        A6: [
+            PF12<Alternate<AF12>>
+        ]
+        A7: [
+            PF13<Alternate<AF12>>
+        ]
+        A8: [
+            PF14<Alternate<AF12>>
+        ]
+        A9: [
+            PF15<Alternate<AF12>>
+        ]
+        BA0: [
+            PG4<Alternate<AF12>>
+        ]
+        BA1: [
+            PG5<Alternate<AF12>>
+        ]
+        CLK: [
+            PD3<Alternate<AF12>>
+        ]
+        D0: [
+            PD14<Alternate<AF12>>
+        ]
+        D1: [
+            PD15<Alternate<AF12>>
+        ]
+        D10: [
+            PE13<Alternate<AF12>>
+        ]
+        D11: [
+            PE14<Alternate<AF12>>
+        ]
+        D12: [
+            PE15<Alternate<AF12>>
+        ]
+        D13: [
+            PD8<Alternate<AF12>>
+        ]
+        D14: [
+            PD9<Alternate<AF12>>
+        ]
+        D15: [
+            PD10<Alternate<AF12>>
+        ]
+        D16: [
+            PH8<Alternate<AF12>>,
+        ]
+        D17: [
+            PH9<Alternate<AF12>>,
+        ]
+        D18: [
+            PH10<Alternate<AF12>>,
+        ]
+        D19: [
+            PH11<Alternate<AF12>>,
+        ]
+        D2: [
+            PD0<Alternate<AF12>>
+        ]
+        D20: [
+            PH12<Alternate<AF12>>,
+        ]
+        D21: [
+            PH13<Alternate<AF12>>,
+        ]
+        D22: [
+            PH14<Alternate<AF12>>,
+        ]
+        D23: [
+            PH15<Alternate<AF12>>,
+        ]
+        D24: [
+            PI0<Alternate<AF12>>
+        ]
+        D25: [
+            PI1<Alternate<AF12>>
+        ]
+        D26: [
+            PI2<Alternate<AF12>>,
+        ]
+        D27: [
+            PI3<Alternate<AF12>>
+        ]
+        D28: [
+            PI6<Alternate<AF12>>
+        ]
+        D29: [
+            PI7<Alternate<AF12>>
+        ]
+        D3: [
+            PD1<Alternate<AF12>>
+        ]
+        D30: [
+            PI9<Alternate<AF12>>
+        ]
+        D31: [
+            PI10<Alternate<AF12>>
+        ]
+        D4: [
+            PE7<Alternate<AF12>>
+        ]
+        D5: [
+            PE8<Alternate<AF12>>
+        ]
+        D6: [
+            PE9<Alternate<AF12>>
+        ]
+        D7: [
+            PE10<Alternate<AF12>>
+        ]
+        D8: [
+            PE11<Alternate<AF12>>
+        ]
+        D9: [
+            PE12<Alternate<AF12>>
+        ]
+        DA0: [
+            PD14<Alternate<AF12>>
+        ]
+        DA1: [
+            PD15<Alternate<AF12>>
+        ]
+        DA10: [
+            PE13<Alternate<AF12>>
+        ]
+        DA11: [
+            PE14<Alternate<AF12>>
+        ]
+        DA12: [
+            PE15<Alternate<AF12>>
+        ]
+        DA13: [
+            PD8<Alternate<AF12>>
+        ]
+        DA14: [
+            PD9<Alternate<AF12>>
+        ]
+        DA15: [
+            PD10<Alternate<AF12>>
+        ]
+        DA2: [
+            PD0<Alternate<AF12>>
+        ]
+        DA3: [
+            PD1<Alternate<AF12>>
+        ]
+        DA4: [
+            PE7<Alternate<AF12>>
+        ]
+        DA5: [
+            PE8<Alternate<AF12>>
+        ]
+        DA6: [
+            PE9<Alternate<AF12>>
+        ]
+        DA7: [
+            PE10<Alternate<AF12>>
+        ]
+        DA8: [
+            PE11<Alternate<AF12>>
+        ]
+        DA9: [
+            PE12<Alternate<AF12>>
+        ]
+        INT: [
+            PG7<Alternate<AF12>>,
+            #[cfg(any(feature = "stm32f722",
+                      feature = "stm32f723",
+                      feature = "stm32f730",
+                      feature = "stm32f732",
+                      feature = "stm32f733"))]
+            PG11<Alternate<AF12>>
+        ]
+        NBL0: [
+            PE0<Alternate<AF12>>
+        ]
+        NBL1: [
+            PE1<Alternate<AF12>>
+        ]
+        NBL2: [
+            PI4<Alternate<AF12>>
+        ]
+        NBL3: [
+            PI5<Alternate<AF12>>
+        ]
+        NCE: [
+            #[cfg(any(feature = "stm32f765",
+                      feature = "stm32f767",
+                      feature = "stm32f769",
+                      feature = "stm32f777",
+                      feature = "stm32f778",
+                      feature = "stm32f779"))]
+            PC8<Alternate<AF9>>,
+            PG9<Alternate<AF12>>
+        ]
+        NE1: [
+            #[cfg(any(feature = "stm32f765",
+                      feature = "stm32f767",
+                      feature = "stm32f769",
+                      feature = "stm32f777",
+                      feature = "stm32f778",
+                      feature = "stm32f779"))]
+            PC7<Alternate<AF9>>,
+            PD7<Alternate<AF12>>
+        ]
+        NE2: [
+            #[cfg(any(feature = "stm32f765",
+                      feature = "stm32f767",
+                      feature = "stm32f769",
+                      feature = "stm32f777",
+                      feature = "stm32f778",
+                      feature = "stm32f779"))]
+            PC8<Alternate<AF9>>,
+            PG9<Alternate<AF12>>
+        ]
+        NE3: [
+            #[cfg(any(feature = "stm32f765",
+                      feature = "stm32f767",
+                      feature = "stm32f769",
+                      feature = "stm32f777",
+                      feature = "stm32f778",
+                      feature = "stm32f779"))]
+            PG6<Alternate<AF12>>,
+            PG10<Alternate<AF12>>
+        ]
+        NE4: [
+            PG12<Alternate<AF12>>
+        ]
+        NL: [
+            PB7<Alternate<AF12>>
+        ]
+        NOE: [
+            PD4<Alternate<AF12>>
+        ]
+        NWAIT: [
+            #[cfg(any(feature = "stm32f765",
+                      feature = "stm32f767",
+                      feature = "stm32f769",
+                      feature = "stm32f777",
+                      feature = "stm32f778",
+                      feature = "stm32f779"))]
+            PC6<Alternate<AF9>>,
+            PD6<Alternate<AF12>>
+        ]
+        NWE: [
+            PD5<Alternate<AF12>>
+        ]
+        SDCKE0: [
+            PC3<Alternate<AF12>>,
+            PC5<Alternate<AF12>>,
+            PH2<Alternate<AF12>>
+        ]
+        SDCKE1: [
+            PB5<Alternate<AF12>>,
+            PH7<Alternate<AF12>>
+        ]
+        SDCLK: [
+            PG8<Alternate<AF12>>
+        ]
+        SDNCAS: [
+            PG15<Alternate<AF12>>
+        ]
+        SDNE0: [
+            PC2<Alternate<AF12>>,
+            PC4<Alternate<AF12>>,
+            PH3<Alternate<AF12>>
+        ]
+        SDNE1: [
+            PB6<Alternate<AF12>>,
+            PH6<Alternate<AF12>>
+        ]
+        SDNRAS: [
+            PF11<Alternate<AF12>>
+        ]
+        SDNWE: [
+            PA7<Alternate<AF12>>,
+            PC0<Alternate<AF12>>,
+            PH5<Alternate<AF12>>
+        ]
+}

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -1,4 +1,6 @@
 //! HAL for Flexible memory controller (FMC)
+//!
+//! See the stm32-fmc [usage guide](https://github.com/stm32-rs/stm32-fmc#usage)
 
 // From stm32_fmc
 use stm32_fmc::FmcPeripheral;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,9 @@ pub mod delay;
 #[cfg(feature = "device-selected")]
 pub mod dma;
 
+#[cfg(all(feature = "device-selected", feature = "fmc"))]
+pub mod fmc;
+
 #[cfg(feature = "device-selected")]
 pub mod gpio;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "fmc")]
+pub use crate::fmc::FmcExt as _stm327xx_hal_fmc_FmcExt;
+
 pub use crate::gpio::GpioExt as _stm327xx_hal_gpio_GpioExt;
 pub use crate::hal::digital::v2::{InputPin, OutputPin};
 pub use crate::hal::prelude::*;


### PR DESCRIPTION
Uses [stm32-fmc](https://github.com/stm32-rs/stm32-fmc)

* Only SDRAM supported so far
* stm32-fmc [only supports some of the f7 family](https://github.com/stm32-rs/stm32-fmc/blob/master/src/ral/peripherals/fmc.rs#L7), but I think it could be extended to cover the rest quite easily