### PR TITLE
Fix compile error in serial_dma example

### DIFF
--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -49,6 +49,7 @@ fn main() -> ! {
         serial::Config {
             baud_rate: 115_200.bps(),
             oversampling: serial::Oversampling::By16,
+            character_match: None,
         },
     );
     let (mut tx, mut rx) = serial.split();


### PR DESCRIPTION
It was introduced with #64

Fixes #76