### PR TITLE
Initial Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mcu:
+          - stm32f722
+          - stm32f723
+          - stm32f732
+          - stm32f733
+          - stm32f745
+          - stm32f746
+          - stm32f756
+          - stm32f765
+          - stm32f767
+          - stm32f769
+          - stm32f777
+          - stm32f778
+          - stm32f779
+        rust:
+          - stable
+        include:
+          - rust: nightly
+            mcu: stm32f746
+            experimental: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: thumbv7em-none-eabihf
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features=${{ matrix.mcu }},usb_fs --examples
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features=${{ matrix.mcu }},usb_fs --examples --release
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --features=${{ matrix.mcu }},rt,usb_fs --examples
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=${{ matrix.mcu }} --target x86_64-unknown-linux-gnu --lib

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+
+name: Clippy
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: For now, allow clippy::erasing_op
+          # TODO: Enable clippy on examples via `--examples`
+          args: --target thumbv7em-none-eabihf --features=rt,stm32f746 -- --allow clippy::erasing_op

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,20 @@
+on: [push, pull_request]
+
+name: Code formatting check
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check


### PR DESCRIPTION
This patch provides an initial port of the current Travis CI
configuration to Github Actions to improve our CI overall and be more
consistent with the other stm32-hal crates. It also enables a basic
`clippy` lint check on the crate. At the moment, there are quite a few
warnings and errors that should be fixed in the future. Travis CI
support has been left unmodified for now, but should be removed later
too.

This is part 1 of #89 