### PR TITLE
WIP: I2c timing calculation, simple custom algorithm skeleton

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -331,10 +331,10 @@ macro_rules! hal {
                     // t_sync + dnf delay
                     let t_dnf = (dnf) as f32/ self.pclk as f32;
                     // if analog filter is enabled then it offer about 50 - 70 ns delay
-                    let t_af:f32 = if self.i2c.cr1.read().anfoff().is_disabled(){ 
-                        0.0 
-                    } else { 
-                        60.0/1_000_000_000f32 
+                    let t_af:f32 = if self.i2c.cr1.read().anfoff().is_disabled(){
+                        0.0
+                    } else {
+                        60.0/1_000_000_000f32
                     };
 
                     let t_sync = 3.0/clocks.sysclk().0 as f32;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -332,7 +332,7 @@ macro_rules! hal {
                     let t_dnf = (dnf + 3 ) as f32/ self.pclk as f32;
                     // if analog filter is enabled then it offer about 50 - 70 ns delay
                     let t_af:f32 = if self.i2c.cr1.read().anfoff().is_disabled(){ 0.0 } else { 70.0/1_000_000_000f32 };
-                    
+
                     let t_fall:f32 =  70.0/1_000_000_000f32 ;
                     let t_delay = (t_dnf + t_af + t_fall);
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -334,7 +334,7 @@ macro_rules! hal {
                     let t_af:f32 = if self.i2c.cr1.read().anfoff().is_disabled(){ 0.0 } else { 60.0/1_000_000_000f32 };
 
                     let t_sync = 3.0/clocks.sysclk().0 as f32;
-                    // fall or rise time 
+                    // fall or rise time
                     let t_fall:f32 =  30f32/1_000_000_000f32;
                     // t_sync1 + t_sync2
                     let t_delay = 2f32*(t_dnf + t_af + t_fall+ t_sync);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -331,7 +331,11 @@ macro_rules! hal {
                     // t_sync + dnf delay
                     let t_dnf = (dnf) as f32/ self.pclk as f32;
                     // if analog filter is enabled then it offer about 50 - 70 ns delay
-                    let t_af:f32 = if self.i2c.cr1.read().anfoff().is_disabled(){ 0.0 } else { 60.0/1_000_000_000f32 };
+                    let t_af:f32 = if self.i2c.cr1.read().anfoff().is_disabled(){ 
+                        0.0 
+                    } else { 
+                        60.0/1_000_000_000f32 
+                    };
 
                     let t_sync = 3.0/clocks.sysclk().0 as f32;
                     // fall or rise time


### PR DESCRIPTION
a simple way to calculate TIMINGR values.
  | measured frequancy   | expected    | %error   |after implementation of delay  |
  | ----------------------------- | ---------------| ----------- |----------------------------------------------------------------------|
  | 98.7khz                       | 100khz       | 1.3%      | 100.8KHz                                                                  |
  | 282.3khz                     | 300khz       | 5.9%      | 301KHz                                                                     |
  | 452.3khz                     | 500khz       | 9.5%      | 496KHz                                                                     |
  | 600khz                        | 700khz       | 14.3%    | 694KHz                                                                     |
  | 827khz                        | 1Mhz          | 17.3%    | 990KHz                                                                     |

i used cheap logic analyzer. result may vary slightly on CRO. 
higher % of error on high clocks due to tsync time which i ignored it for simplicity. i will add it soon (WIP)
also optional duty cycle option is  WIP
requesting for reviews

solves: #71