### PR TITLE
[rdy] random number generation implimented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ stm32f7 = "0.11.0"
 micromath = "1.0.0"
 synopsys-usb-otg = { version = "0.2.3", features = ["cortex-m"], optional = true }
 stm32-fmc = { version = "0.2.0", features = ["sdram"], optional = true }
+rand_core = "0.5.1"
 
 [dependencies.bare-metal]
 version = "0.2.4"
@@ -125,3 +126,6 @@ required-features = ["stm32f767", "rt"]
 [[example]]
 name = "usb_serial"
 required-features = ["stm32f723", "rt", "synopsys-usb-otg"]
+
+[[example]]
+name = "rng"

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -1,0 +1,22 @@
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+/// generates a random number and displays it to the openocd console
+use panic_semihosting as _;
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::hprintln;
+use stm32f7xx_hal::{pac, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    let p = pac::Peripherals::take().unwrap();
+    let mut rng = p.RNG.init();
+    let val = rng.get_rand().unwrap();
+    hprintln!("random value {}", val).unwrap();
+    loop {
+        core::sync::atomic::spin_loop_hint();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,9 @@ pub mod signature;
 #[cfg(feature = "device-selected")]
 pub mod i2c;
 
+#[cfg(feature = "device-selected")]
+pub mod rng;
+
 #[cfg(feature = "ltdc")]
 pub mod ltdc;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,4 +5,5 @@ pub use crate::gpio::GpioExt as _stm327xx_hal_gpio_GpioExt;
 pub use crate::hal::digital::v2::{InputPin, OutputPin};
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32f7xx_hal_rcc_RccExt;
+pub use crate::rng::RngExt as _stm32f7xx_hal_rng_RngExt;
 pub use crate::time::U32Ext as _stm327xx_hal_time_U32Ext;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,5 +5,5 @@ pub use crate::gpio::GpioExt as _stm327xx_hal_gpio_GpioExt;
 pub use crate::hal::digital::v2::{InputPin, OutputPin};
 pub use crate::hal::prelude::*;
 pub use crate::rcc::RccExt as _stm32f7xx_hal_rcc_RccExt;
-pub use crate::rng::RngExt as _stm32f7xx_hal_rng_RngExt;
+pub use crate::rng::RngExt as _;
 pub use crate::time::U32Ext as _stm327xx_hal_time_U32Ext;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -782,7 +782,7 @@ impl CFGR {
 /// Frozen clock frequencies
 ///
 /// The existence of this value indicates that the clock configuration can no longer be changed
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Clocks {
     hclk: Hertz,
     pclk1: Hertz,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,134 @@
+use core::cmp;
+use core::mem;
+
+use crate::pac::RCC;
+use crate::pac::RNG;
+use core::num::NonZeroU32;
+use core::ops::Shl;
+use embedded_hal::blocking::rng::Read;
+use rand_core::RngCore;
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The RNG_CLK was not correctly detected (fRNG_CLK< fHCLK/16).
+    /// See CECS in RNG peripheral documentation.
+    ClockError = 2,
+    /// RNG detected more than 64 consecutive bits of the same value (0 or 1) OR
+    /// more than 32 consecutive 01 pairs.
+    /// See SECS in RNG peripheral documentation.
+    SeedError = 4,
+}
+
+impl From<ErrorKind> for rand_core::Error {
+    fn from(err: ErrorKind) -> rand_core::Error {
+        let err_code = NonZeroU32::new(rand_core::Error::CUSTOM_START + err as u32).unwrap();
+        rand_core::Error::from(err_code)
+    }
+}
+
+pub trait RngExt {
+    fn init(self) -> Rng;
+}
+
+impl RngExt for RNG {
+    /// Enable RNG_CLK and the RNG peripheral.
+    /// Note that clocks must already be configured such that RNG_CLK is not less than 1/16 HCLK,
+    /// otherwise all reads of the RNG would return a ClockError (CECS error).
+    fn init(self) -> Rng {
+        let rcc = unsafe { &*RCC::ptr() };
+
+        cortex_m::interrupt::free(|_| {
+            // need set enable pll for this operation
+            if rcc.cr.read().pllrdy().bit_is_clear() {
+                rcc.cr.modify(|_, w| w.pllon().set_bit());
+                // wait till pll is ready
+                while rcc.cr.read().pllrdy().bit_is_clear() {}
+            }
+            // enable RNG_CLK (peripheral clock)
+            rcc.ahb2enr.modify(|_, w| w.rngen().enabled());
+            // give RNG_CLK time to start
+            let _ = rcc.ahb2enr.read().rngen().is_enabled();
+
+            // reset the RNG
+            rcc.ahb2rstr.modify(|_, w| w.rngrst().set_bit());
+            rcc.ahb2rstr.modify(|_, w| w.rngrst().clear_bit());
+
+            // enable the RNG peripheral
+            self.cr.modify(|_, w| w.rngen().set_bit());
+            // hardware check for clock is used
+            // instead of software calculation, which may be inaccurate.
+            // until data is available we will check for CECS flag, if it is set
+            // means that clock error occured
+            while !self.sr.read().drdy().bit() {
+                assert!(!self.sr.read().cecs().bit());
+            }
+        });
+
+        Rng { rb: self }
+    }
+}
+
+pub struct Rng {
+    rb: RNG,
+}
+
+impl Rng {
+    /// Returns 32 bits of random data from RNDATA, or error.
+    /// May fail if, for example RNG_CLK is misconfigured.
+    pub fn get_rand(&mut self) -> Result<u32, ErrorKind> {
+        loop {
+            let status = self.rb.sr.read();
+            if status.cecs().bit() {
+                return Err(ErrorKind::ClockError);
+            }
+            if status.secs().bit() {
+                return Err(ErrorKind::SeedError);
+            }
+            if status.drdy().bit() {
+                return Ok(self.rb.dr.read().rndata().bits());
+            }
+        }
+    }
+
+    pub fn release(self) -> RNG {
+        self.rb
+    }
+}
+
+impl Read for Rng {
+    type Error = rand_core::Error;
+
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.try_fill_bytes(buffer)
+    }
+}
+
+impl RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.get_rand().unwrap()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let w1 = self.next_u32();
+        let w2 = self.next_u32();
+        (w1 as u64).shl(32) | (w2 as u64)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.try_fill_bytes(dest).unwrap()
+    }
+
+    /// Fills buffer with random values, or returns an error
+    fn try_fill_bytes(&mut self, buffer: &mut [u8]) -> Result<(), rand_core::Error> {
+        const BATCH_SIZE: usize = 4 / mem::size_of::<u8>();
+        let mut i = 0_usize;
+        while i < buffer.len() {
+            let random_word = self.get_rand()?;
+            let bytes = random_word.to_ne_bytes();
+            let n = cmp::min(BATCH_SIZE, buffer.len() - i);
+            buffer[i..i + n].copy_from_slice(&bytes[..n]);
+            i += n;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
It is same implementation done in stm32f4xx-hal, but with a small change, i.e. they used software calculation for checking whether rng clk condition meets the requirements or not. which prone to errors as software calculation may not give exact frequency. 
i used status flags for that. 
this addresses #102  