### PR TITLE
solved issue: cant freeze rcc clock when using spi

### DIFF
--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     let mut rx_stream = dma.streams.stream1;
     let mut tx_stream = dma.streams.stream3;
 
-    let dma = dma.handle.enable(&mut rcc);
+    let dma = dma.handle.enable(&mut rcc.ahb1);
 
     let clocks = rcc.cfgr.sysclk(216.mhz()).freeze();
 

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -34,8 +34,7 @@ fn main() -> ! {
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi)).enable::<u8>(
-        &mut rcc,
+    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi), &mut rcc.apb1).enable::<u8>(
         spi::ClockDivider::DIV32,
         spi::Mode {
             polarity: spi::Polarity::IdleHigh,

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -34,7 +34,8 @@ fn main() -> ! {
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi), &mut rcc.apb1).enable::<u8>(
+    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi)).enable::<u8>(
+        &mut rcc.apb1,
         spi::ClockDivider::DIV32,
         spi::Mode {
             polarity: spi::Polarity::IdleHigh,

--- a/examples/spi_16.rs
+++ b/examples/spi_16.rs
@@ -33,8 +33,11 @@ fn main() -> ! {
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi), &mut rcc.apb2)
-        .enable::<u16>(spi::ClockDivider::DIV32, embedded_hal::spi::MODE_0);
+    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi)).enable::<u16>(
+        &mut rcc.apb2,
+        spi::ClockDivider::DIV32,
+        embedded_hal::spi::MODE_0,
+    );
 
     // Use a button to control output via the Maxim Integrated MAX5214 DAC.
     loop {

--- a/examples/spi_16.rs
+++ b/examples/spi_16.rs
@@ -33,11 +33,8 @@ fn main() -> ! {
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi)).enable::<u16>(
-        &mut rcc,
-        spi::ClockDivider::DIV32,
-        embedded_hal::spi::MODE_0,
-    );
+    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi), &mut rcc.apb2)
+        .enable::<u16>(spi::ClockDivider::DIV32, embedded_hal::spi::MODE_0);
 
     // Use a button to control output via the Maxim Integrated MAX5214 DAC.
     loop {

--- a/examples/spi_dma.rs
+++ b/examples/spi_dma.rs
@@ -39,13 +39,14 @@ fn main() -> ! {
     let mut rx_stream = dma.streams.stream0;
     let mut tx_stream = dma.streams.stream5;
 
-    let dma = dma.handle.enable(&mut rcc);
+    let dma = dma.handle.enable(&mut rcc.ahb1);
 
     // Set NCS pin to high (disabled) initially
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi), &mut rcc.apb1).enable(
+    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi)).enable(
+        &mut rcc.apb1,
         spi::ClockDivider::DIV32,
         spi::Mode {
             polarity: spi::Polarity::IdleHigh,

--- a/examples/spi_dma.rs
+++ b/examples/spi_dma.rs
@@ -45,8 +45,7 @@ fn main() -> ! {
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi)).enable(
-        &mut rcc,
+    let mut spi = Spi::new(p.SPI3, (sck, miso, mosi), &mut rcc.apb1).enable(
         spi::ClockDivider::DIV32,
         spi::Mode {
             polarity: spi::Polarity::IdleHigh,

--- a/examples/spi_dma_16.rs
+++ b/examples/spi_dma_16.rs
@@ -38,14 +38,17 @@ fn main() -> ! {
     let mut rx_stream = dma.streams.stream0;
     let mut tx_stream = dma.streams.stream3;
 
-    let dma = dma.handle.enable(&mut rcc);
+    let dma = dma.handle.enable(&mut rcc.ahb1);
 
     // Set NCS pin to high (disabled) initially
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi), &mut rcc.apb2)
-        .enable(spi::ClockDivider::DIV32, embedded_hal::spi::MODE_0);
+    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi)).enable(
+        &mut rcc.apb2,
+        spi::ClockDivider::DIV32,
+        embedded_hal::spi::MODE_0,
+    );
 
     // Create the buffer we're going to use for DMA. This is safe, as this
     // function won't return as long as the program runs, so there's no chance

--- a/examples/spi_dma_16.rs
+++ b/examples/spi_dma_16.rs
@@ -44,11 +44,8 @@ fn main() -> ! {
     ncs.set_high().unwrap();
 
     // Initialize SPI
-    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi)).enable(
-        &mut rcc,
-        spi::ClockDivider::DIV32,
-        embedded_hal::spi::MODE_0,
-    );
+    let mut spi = Spi::new(p.SPI1, (sck, spi::NoMiso, mosi), &mut rcc.apb2)
+        .enable(spi::ClockDivider::DIV32, embedded_hal::spi::MODE_0);
 
     // Create the buffer we're going to use for DMA. This is safe, as this
     // function won't return as long as the program runs, so there's no chance

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -16,7 +16,7 @@ use crate::{
         dma2::{self, st::cr},
         Interrupt, DMA1, DMA2, NVIC,
     },
-    rcc::Rcc,
+    rcc::{sealed::RccBus, Enable, Reset},
     serial, spi, state,
 };
 
@@ -31,7 +31,7 @@ pub struct DMA<I> {
 
 impl<I> DMA<I>
 where
-    I: Instance,
+    I: Instance + Enable + Reset,
 {
     /// Creates a new instance of `DMA`
     ///
@@ -55,7 +55,7 @@ pub struct Handle<I, State> {
 
 impl<I> Handle<I, state::Disabled>
 where
-    I: Instance,
+    I: Instance + Reset + Enable,
 {
     fn new(instance: I) -> Self {
         Self {
@@ -65,8 +65,9 @@ where
     }
 
     /// Initializes the DMA instance
-    pub fn enable(self, rcc: &mut Rcc) -> Handle<I, state::Enabled> {
-        I::enable(rcc);
+    pub fn enable(self, apb: &mut <I as RccBus>::Bus) -> Handle<I, state::Enabled> {
+        I::reset(apb);
+        I::enable(apb);
 
         Handle {
             dma: self.dma,
@@ -599,26 +600,20 @@ impl_channel!(
 ///
 /// This is an internal trait. End users neither need to implement it, nor use
 /// it directly.
-pub trait Instance {
-    fn enable(rcc: &mut Rcc);
-}
+pub trait Instance {}
 
 macro_rules! impl_instance {
-    ($($name:ty, $reset_reg:ident, $enable_reg:ident;)*) => {
+    ($($name:ty;)*) => {
         $(
             impl Instance for $name {
-                fn enable(rcc: &mut Rcc) {
-                    rcc.ahb1.rstr().modify(|_, w| w.$reset_reg().clear_bit());
-                    rcc.ahb1.enr().modify(|_, w| w.$enable_reg().enabled());
-                }
             }
         )*
     }
 }
 
 impl_instance!(
-    DMA1, dma1rst, dma1en;
-    DMA2, dma2rst, dma2en;
+    DMA1;
+    DMA2;
 );
 
 /// Used by [`Transfer::enable_interrupts`] to identify DMA interrupts

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -35,8 +35,7 @@ where
     P: Pins<I>,
 {
     /// Create a new instance of the SPI API
-    pub fn new(instance: I, pins: P, apb: &mut <I as RccBus>::Bus) -> Self {
-        I::enable(apb);
+    pub fn new(instance: I, pins: P) -> Self {
         Self {
             spi: instance,
             pins,
@@ -45,10 +44,16 @@ where
     }
 
     /// Initialize the SPI peripheral
-    pub fn enable<Word>(self, clock_divider: ClockDivider, mode: Mode) -> Spi<I, P, Enabled<Word>>
+    pub fn enable<Word>(
+        self,
+        apb: &mut <I as RccBus>::Bus,
+        clock_divider: ClockDivider,
+        mode: Mode,
+    ) -> Spi<I, P, Enabled<Word>>
     where
         Word: SupportedWordSize,
     {
+        I::enable(apb);
         let cpol = mode.polarity == Polarity::IdleHigh;
         let cpha = mode.phase == Phase::CaptureOnSecondTransition;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -16,7 +16,7 @@ use embedded_hal::{
 use crate::{
     gpio::{self, Alternate, AF5, AF6, AF7},
     pac::{self, spi1::cr2},
-    rcc::Rcc,
+    rcc::{sealed::RccBus, Enable},
     state,
 };
 
@@ -31,11 +31,12 @@ pub struct Spi<I, P, State> {
 
 impl<I, P> Spi<I, P, state::Disabled>
 where
-    I: Instance,
+    I: Instance + Enable,
     P: Pins<I>,
 {
     /// Create a new instance of the SPI API
-    pub fn new(instance: I, pins: P) -> Self {
+    pub fn new(instance: I, pins: P, apb: &mut <I as RccBus>::Bus) -> Self {
+        I::enable(apb);
         Self {
             spi: instance,
             pins,
@@ -44,19 +45,13 @@ where
     }
 
     /// Initialize the SPI peripheral
-    pub fn enable<Word>(
-        self,
-        rcc: &mut Rcc,
-        clock_divider: ClockDivider,
-        mode: Mode,
-    ) -> Spi<I, P, Enabled<Word>>
+    pub fn enable<Word>(self, clock_divider: ClockDivider, mode: Mode) -> Spi<I, P, Enabled<Word>>
     where
         Word: SupportedWordSize,
     {
         let cpol = mode.polarity == Polarity::IdleHigh;
         let cpha = mode.phase == Phase::CaptureOnSecondTransition;
 
-        self.spi.enable_clock(rcc);
         self.spi.configure::<Word>(clock_divider.into(), cpol, cpha);
 
         Spi {
@@ -228,7 +223,6 @@ where
 ///
 /// Users of this crate should not implement this trait.
 pub trait Instance {
-    fn enable_clock(&self, rcc: &mut Rcc);
     fn configure<Word>(&self, br: u8, cpol: bool, cpha: bool)
     where
         Word: SupportedWordSize;
@@ -282,10 +276,6 @@ macro_rules! impl_instance {
     ) => {
         $(
             impl Instance for $name {
-                fn enable_clock(&self, rcc: &mut Rcc) {
-                    rcc.$bus.rstr().modify(|_, w| w.$reset().clear_bit());
-                    rcc.$bus.enr().modify(|_, w| w.$enable().enabled());
-                }
 
                 // I don't like putting this much code into the macro, but I
                 // have to: There are two different SPI variants in the PAC, and


### PR DESCRIPTION
solves #65 
this PR tackles both when using SPI as well as dma, so there are 2 commits separate,
when called spi enable it requires mutable reference to rcc
```
    let mut spi1:Spi1 = Spi::new(p.SPI1, (sck, miso, mosi)).enable(
        &mut rcc,
        ClockDivider::DIV8,
        spi::Mode{
            polarity : Polarity::IdleHigh,
            phase : Phase::CaptureOnFirstTransition,
        }
        );

```
which fails when when freeze is called,
```
18 |     let clks = rcc.cfgr.sysclk(32.mhz()).freeze();
   |                -------- value partially moved here
...
25 |         &mut rcc,
   |         ^^^^^^^^ value borrowed here after partial move
   |
   = note: partial move occurs because `rcc.cfgr` has type `stm32f7xx_hal::rcc::CFGR`, which does not implement the `Copy` trait
```
when enabling spi we can use `rcc::Enable` which solves above issue, now instead of giving mutable reference of rcc to enable function we are giving mutable reference to rccbus to new function same as in i2c.

i am not a professional in this case, feel free to reject this PR if it is wrong