### PR TITLE
Use CamelCase for gpio::Edge enum variants

### DIFF
--- a/examples/exti_button.rs
+++ b/examples/exti_button.rs
@@ -41,7 +41,7 @@ fn main() -> ! {
     let gpioc = pac_periph.GPIOC.split();
     let mut button = gpioc.pc13.into_floating_input();
     button.make_interrupt_source(&mut syscfg, &mut rcc);
-    button.trigger_on_edge(&mut exti, Edge::RISING);
+    button.trigger_on_edge(&mut exti, Edge::Rising);
     button.enable_interrupt(&mut exti);
 
     // Freeze clocks

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -73,9 +73,9 @@ pub enum Speed {
 
 #[derive(Debug, PartialEq)]
 pub enum Edge {
-    RISING,
-    FALLING,
-    RISING_FALLING,
+    Rising,
+    Falling,
+    RisingFalling,
 }
 
 /// External Interrupt Pin
@@ -232,15 +232,15 @@ macro_rules! gpio {
                 /// Generate interrupt on rising edge, falling edge or both
                 fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                     match edge {
-                        Edge::RISING => {
+                        Edge::Rising => {
                             exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::FALLING => {
+                        Edge::Falling => {
                             exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                         },
-                        Edge::RISING_FALLING => {
+                        Edge::RisingFalling => {
                             exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                             exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                         }
@@ -641,15 +641,15 @@ macro_rules! gpio {
                     /// Generate interrupt on rising edge, falling edge or both
                     fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: Edge) {
                         match edge {
-                            Edge::RISING => {
+                            Edge::Rising => {
                                 exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::FALLING => {
+                            Edge::Falling => {
                                 exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                             },
-                            Edge::RISING_FALLING => {
+                            Edge::RisingFalling => {
                                 exti.rtsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                                 exti.ftsr.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                             }


### PR DESCRIPTION
ref: [h7xx](https://github.com/stm32-rs/stm32h7xx-hal/pull/179), [l4xx](https://github.com/stm32-rs/stm32l4xx-hal/pull/187), [f1xx](https://github.com/stm32-rs/stm32f1xx-hal/pull/303), [f4xx](https://github.com/stm32-rs/stm32f4xx-hal/pull/250)
