### PR TITLE
changed to bxcan >=0.4,  <0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ micromath = "1.0.0"
 synopsys-usb-otg = { version = "0.2.3", features = ["cortex-m"], optional = true }
 stm32-fmc = { version = "0.2.0", features = ["sdram"], optional = true }
 rand_core = "0.5.1"
-bxcan = "0.5"
+bxcan = ">=0.4,  <0.6"
 
 [dependencies.bare-metal]
 version = "0.2.4"


### PR DESCRIPTION
This PR is to relax the version requirement for `bxcan`. See discussion at https://github.com/stm32-rs/stm32f7xx-hal/issues/114#issuecomment-812658708