### PR TITLE
Set PLLM, PLLN and PLLP

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -638,6 +638,19 @@ impl CFGR {
             self.use_pll = false;
             return;
         }
+        
+        let p_ok = (sysclk as u64)
+            == (base_clk as u64 * self.plln as u64
+                / self.pllm as u64
+                / match self.pllp {
+                    PLLP::Div2 => 2,
+                    PLLP::Div4 => 4,
+                    PLLP::Div6 => 6,
+                    PLLP::Div8 => 8,
+                });
+        if p_ok && q.is_none() {
+            return;
+        }
 
         if let Some((m, n, p, q)) = CFGR::calculate_mnpq(base_clk, FreqRequest { p, q }) {
             self.pllm = m as u8;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -639,8 +639,8 @@ impl CFGR {
             return;
         }
         
-        /* We check if (pllm, plln, pllp) allow to obtain the requested Sysclk, 
-           so that we don't have to calculate them */
+        // We check if (pllm, plln, pllp) allow to obtain the requested Sysclk,
+        // so that we don't have to calculate them
         let p_ok = (sysclk as u64)
             == (base_clk as u64 * self.plln as u64
                 / self.pllm as u64

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -639,6 +639,8 @@ impl CFGR {
             return;
         }
         
+        /* We check if (pllm, plln, pllp) allow to obtain the requested Sysclk, 
+           so that we don't have to calculate them */
         let p_ok = (sysclk as u64)
             == (base_clk as u64 * self.plln as u64
                 / self.pllm as u64

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -638,7 +638,7 @@ impl CFGR {
             self.use_pll = false;
             return;
         }
-        
+
         // We check if (pllm, plln, pllp) allow to obtain the requested Sysclk,
         // so that we don't have to calculate them
         let p_ok = (sysclk as u64)


### PR DESCRIPTION
This can be useful if we decide to set the values in order to reduce the computation time due to calculate_mnpq() function. (Clocks.freeze() computation's time reduced by approximately 1s)