### PR TITLE
Add support for some LCD controllers using the FMC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ version = "0.2.3"
 default-features = false
 version = "1.0.2"
 
+[dependencies.display-interface]
+optional = true
+version = "0.4.1"
+
 [dev-dependencies]
 cortex-m-semihosting = "0.3.3"
 panic-halt = "0.2.0"
@@ -59,7 +63,7 @@ usb_hs_phy = []
 rt = ["stm32f7/rt"]
 stm32f722 = ["stm32f7/stm32f7x2", "device-selected"]
 stm32f723 = ["stm32f7/stm32f7x3", "device-selected", "usb_hs_phy"]
-stm32f730 = ["stm32f7/stm32f730", "device-selected", "usb_hs_phy"]
+stm32f730 = ["stm32f7/stm32f730", "device-selected", "usb_hs_phy", "fmc"]
 stm32f732 = ["stm32f7/stm32f7x2", "device-selected"]
 stm32f733 = ["stm32f7/stm32f7x3", "device-selected", "usb_hs_phy"]
 stm32f745 = ["stm32f7/stm32f745", "device-selected", "fmc"]
@@ -71,6 +75,8 @@ stm32f769 = ["stm32f7/stm32f7x9", "device-selected", "ltdc", "fmc"]
 stm32f777 = ["stm32f7/stm32f7x7", "device-selected", "ltdc", "fmc"]
 stm32f778 = ["stm32f7/stm32f7x9", "device-selected", "ltdc", "fmc"]
 stm32f779 = ["stm32f7/stm32f7x9", "device-selected", "ltdc", "fmc"]
+
+fmc_lcd = ["display-interface"]
 
 usb_fs = ["synopsys-usb-otg", "synopsys-usb-otg/fs"]
 usb_hs = ["synopsys-usb-otg", "synopsys-usb-otg/hs"]

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -65,7 +65,7 @@ use crate::gpio::{Alternate, AF12};
 
 /// Storage type for Flexible Memory Controller and its clocks
 pub struct FMC {
-    _fmc: stm32::FMC,
+    pub fmc: stm32::FMC,
     hclk: Hertz,
 }
 
@@ -105,7 +105,7 @@ impl FmcExt for stm32::FMC {
     /// New FMC instance
     fn fmc(self, clocks: &Clocks) -> FMC {
         FMC {
-            _fmc: self,
+            fmc: self,
             hclk: clocks.hclk(),
         }
     }

--- a/src/fmc_lcd/display_interface_impl.rs
+++ b/src/fmc_lcd/display_interface_impl.rs
@@ -1,0 +1,76 @@
+use display_interface::{DataFormat, DisplayError, WriteOnlyDataCommand};
+
+use super::{Lcd, SubBank};
+
+impl<S> WriteOnlyDataCommand for Lcd<S>
+where
+    S: SubBank,
+{
+    fn send_commands(&mut self, cmd: DataFormat<'_>) -> Result<(), DisplayError> {
+        match cmd {
+            DataFormat::U8(slice) => {
+                for value in slice {
+                    self.write_command(u16::from(*value));
+                }
+            }
+            DataFormat::U16(slice) => {
+                for value in slice {
+                    self.write_command(*value);
+                }
+            }
+            DataFormat::U16BE(slice) | DataFormat::U16LE(slice) => {
+                // As long as the data bus is 16 bits wide, the byte order doesn't matter.
+                for value in slice {
+                    self.write_command(*value);
+                }
+            }
+            DataFormat::U8Iter(iter) => {
+                for value in iter {
+                    self.write_command(u16::from(value));
+                }
+            }
+            DataFormat::U16BEIter(iter) | DataFormat::U16LEIter(iter) => {
+                // As long as the data bus is 16 bits wide, the byte order doesn't matter.
+                for value in iter {
+                    self.write_command(value);
+                }
+            }
+            _ => return Err(DisplayError::DataFormatNotImplemented),
+        }
+        Ok(())
+    }
+
+    fn send_data(&mut self, buf: DataFormat<'_>) -> Result<(), DisplayError> {
+        match buf {
+            DataFormat::U8(slice) => {
+                for value in slice {
+                    self.write_data(u16::from(*value));
+                }
+            }
+            DataFormat::U16(slice) => {
+                for value in slice {
+                    self.write_data(*value);
+                }
+            }
+            DataFormat::U16BE(slice) | DataFormat::U16LE(slice) => {
+                // As long as the data bus is 16 bits wide, the byte order doesn't matter.
+                for value in slice {
+                    self.write_data(*value);
+                }
+            }
+            DataFormat::U8Iter(iter) => {
+                for value in iter {
+                    self.write_data(u16::from(value));
+                }
+            }
+            DataFormat::U16BEIter(iter) | DataFormat::U16LEIter(iter) => {
+                // As long as the data bus is 16 bits wide, the byte order doesn't matter.
+                for value in iter {
+                    self.write_data(value);
+                }
+            }
+            _ => return Err(DisplayError::DataFormatNotImplemented),
+        }
+        Ok(())
+    }
+}

--- a/src/fmc_lcd/mod.rs
+++ b/src/fmc_lcd/mod.rs
@@ -1,0 +1,411 @@
+//!
+//! LCD interface using the Flexible Memory Controller (FMC)
+//!
+//! This module is only available if the `fmc_lcd` feature is enabled and the target
+//! microcontroller has an FMC
+//!
+//! This driver is compatible with many LCD driver chips that support the Intel 8080 interface
+//! (also called Display Bus Interface (DBI) type B) with a 16-bit data bus.
+//!
+//! Here are some examples of compatible LCD drivers:
+//! * Sitronix ST7735S
+//! * Sitronix ST7789VI
+//! * Ilitek ILI9327
+//! * Ilitek ILI9320
+//! * Himax HX8357-B
+//!
+//! Higher-level driver code can add support for specific LCD driver
+//! integrated circuits.
+//!
+//! For an overview of how this interface works, see [application note AN2790](https://www.st.com/content/ccc/resource/technical/document/application_note/85/ad/ef/0f/a3/a6/49/9a/CD00201397.pdf/files/CD00201397.pdf/jcr:content/translations/en.CD00201397.pdf).
+//!
+//! # Pins
+//!
+//! To interface with 1-4 LCDs, you will need:
+//! * 16 data pins (0 through 15), shared among all the LCDs
+//! * One NEx (chip select) pin per LCD (up to 4)
+//! * One Ax (address) pin, shared among all the LCDs. This pin is used to select data or command
+//!   mode.
+//!     * You can also supply up to 4 address pins, but they will always have the same output.
+//!     * Caution: Due to hardware limitations, address line A25 cannot be used.
+//! * One NOE (read enable) pin, shared among all the LCDs
+//! * One NWE (write enable) pin, shared among all the LCDs
+//!
+//! # Timing
+//!
+//! Because the correct timing depends on the specific LCD controller and the wiring between the
+//! microcontroller and LCD controller, this driver does not try to calculate the correct
+//! timing settings. Instead, it exposes the access modes and timing options that the STM32F7
+//! hardware supports.
+//!
+//! The default access mode is mode C. For an example timing diagram, refer to reference manual
+//! [RM0090](https://www.st.com/resource/en/reference_manual/dm00031020.pdf),
+//! figures 443 and 444 (on page 1562), or your microcontroller reference manual.
+//!
+//! Access modes A, B, and D are also supported.
+//!
+//! # Basic operation
+//!
+//! 1. Create an `LcdPins` object containing the pins used to communicate with the LCD
+//!
+//! 2. Create default `Timing` objects for the write and read timing
+//!     
+//!     a. (Optional) Adjust the timing to make read and write operations faster, within the limits
+//!        of the wiring and LCD controller
+//!
+//! 3. Pass the FMC peripheral object, pins, read timing, and write timing to `FmcLcd::new`.
+//!    This function will return an `FmcLcd` and one or more `Lcd` objects.
+//!
+//! 4. Use the returned `Lcd` object(s) to configure the controller(s) and display graphics
+
+mod display_interface_impl;
+mod pins;
+mod sealed;
+mod timing;
+
+use core::marker::PhantomData;
+
+use stm32_fmc::FmcPeripheral;
+
+pub use self::pins::{
+    AddressPins, ChipSelect1, ChipSelect2, ChipSelect3, ChipSelect4, ChipSelectPins, DataPins,
+    LcdPins, PinAddress, PinChipSelect1, PinChipSelect2, PinChipSelect3, PinChipSelect4, PinD0,
+    PinD1, PinD10, PinD11, PinD12, PinD13, PinD14, PinD15, PinD2, PinD3, PinD4, PinD5, PinD6,
+    PinD7, PinD8, PinD9, PinReadEnable, PinWriteEnable, Pins,
+};
+pub use self::timing::{AccessMode, Timing};
+
+use crate::prelude::_stm327xx_hal_fmc_FmcExt;
+
+use crate::fmc;
+use crate::pac;
+use crate::pac::FMC;
+use crate::rcc::Clocks;
+
+/// A sub-bank of bank 1, with its own chip select output
+pub trait SubBank: sealed::SealedSubBank {}
+/// Sub-bank 1
+pub struct SubBank1(());
+impl sealed::SealedSubBank for SubBank1 {
+    const BASE_ADDRESS: usize = 0x6000_0000;
+}
+impl SubBank for SubBank1 {}
+/// Sub-bank 2
+pub struct SubBank2(());
+impl sealed::SealedSubBank for SubBank2 {
+    const BASE_ADDRESS: usize = 0x6400_0000;
+}
+impl SubBank for SubBank2 {}
+/// Sub-bank 3
+pub struct SubBank3(());
+impl sealed::SealedSubBank for SubBank3 {
+    const BASE_ADDRESS: usize = 0x6800_0000;
+}
+impl SubBank for SubBank3 {}
+/// Sub-bank 4
+pub struct SubBank4(());
+impl sealed::SealedSubBank for SubBank4 {
+    const BASE_ADDRESS: usize = 0x6c00_0000;
+}
+impl SubBank for SubBank4 {}
+
+/// An FMC configured as an LCD interface
+pub struct FmcLcd<PINS> {
+    pins: PINS,
+    fmc: fmc::FMC,
+}
+
+impl<PINS> FmcLcd<PINS>
+where
+    PINS: Pins,
+{
+    /// Configures the FMC to interface with an LCD using the provided pins
+    ///
+    /// The same timings will be used for all connected LCDs.
+    ///
+    /// The return type includes an `FmcLcd` and either an `Lcd` or a tuple of up to four `Lcd`s,
+    /// depending on the pins given.
+    ///
+    /// The returned `FmcLcd` can be used later to release the FMC and pins for other uses,
+    /// or it can be ignored.
+    ///
+    /// # Return type examples
+    ///
+    /// ## One enable/chip select pin
+    ///
+    /// If you pass an `LcdPins` object with the `enable` field containing a single `ChipSelect1`
+    /// object with a pin, this function will return an `FmcLcd` and an `Lcd<SubBank1>`.
+    ///
+    /// ### Multiple enable/chip select pins
+    ///
+    /// If you pass an `LcdPins` object with the `enable` field containing a tuple of 2-4
+    /// `ChipSelectX` objects, this function will return an `FmcLcd` and a tuple of `Lcd<_>`
+    /// objects. Each `Lcd` is associated with one chip select pin, and can be controlled
+    /// independently.
+    ///
+    /// # Examples
+    ///
+    /// Up to four LCDs can be controlled separately using four chip select pins
+    ///
+    /// ```ignore
+    /// let lcd_pins = LcdPins {
+    ///     data: (
+    ///         gpiod.pd14.into_alternate_af12(),
+    ///         gpiod.pd15.into_alternate_af12(),
+    ///         gpiod.pd0.into_alternate_af12(),
+    ///         gpiod.pd1.into_alternate_af12(),
+    ///         gpioe.pe7.into_alternate_af12(),
+    ///         gpioe.pe8.into_alternate_af12(),
+    ///         gpioe.pe9.into_alternate_af12(),
+    ///         gpioe.pe10.into_alternate_af12(),
+    ///         gpioe.pe11.into_alternate_af12(),
+    ///         gpioe.pe12.into_alternate_af12(),
+    ///         gpioe.pe13.into_alternate_af12(),
+    ///         gpioe.pe14.into_alternate_af12(),
+    ///         gpioe.pe15.into_alternate_af12(),
+    ///         gpiod.pd8.into_alternate_af12(),
+    ///         gpiod.pd9.into_alternate_af12(),
+    ///         gpiod.pd10.into_alternate_af12(),
+    ///     ),
+    ///     // Four address pins, one for each LCD
+    ///     // All of them will have the same output
+    ///     address: (
+    ///         gpiof.pf0.into_alternate_af12(),
+    ///         gpioe.pe2.into_alternate_af12(),
+    ///         gpioe.pe3.into_alternate_af12(),
+    ///         gpiof.pf14.into_alternate_af12(),
+    ///     ),
+    ///     read_enable: gpiod.pd4.into_alternate_af12(),
+    ///     write_enable: gpiod.pd5.into_alternate_af12(),
+    ///     // Four chip select pins, one for each LCD, controlled independently
+    ///     chip_select: (
+    ///         ChipSelect1(gpiod.pd7.into_alternate_af12()),
+    ///         ChipSelect2(gpiog.pg9.into_alternate_af12()),
+    ///         ChipSelect3(gpiog.pg10.into_alternate_af12()),
+    ///         ChipSelect4(gpiog.pg12.into_alternate_af12()),
+    ///     ),
+    /// };
+    ///
+    /// let (_fmc, mut lcds) = FmcLcd::new(dp.FMC, lcd_pins, &Timing::default(), &Timing::default());
+    /// // lcds is a tuple of four `Lcd` objects. Each one can be accessed independently.
+    /// // This is just a basic example of some things that can be done.
+    /// lcds.0.write_command(37);
+    /// lcds.1.write_command(38);
+    /// lcds.2.write_command(39);
+    /// lcds.3.write_command(40);
+    /// ```
+    pub fn new(
+        fmc: FMC,
+        clocks: &Clocks,
+        pins: PINS,
+        read_timing: &Timing,
+        write_timing: &Timing,
+    ) -> (Self, PINS::Lcds) {
+        use self::sealed::Conjure;
+        let mut fmc = fmc.fmc(clocks);
+        // Enable the FMC
+        fmc.enable();
+
+        // Configure memory type and basic interface settings
+        // The reference manuals are sometimes unclear on the distinction between banks
+        // and sub-banks of bank 1. This driver uses addresses in the different sub-banks of
+        // bank 1. The configuration registers for "bank x" (like FMC_BCRx) actually refer to
+        // sub-banks, not banks. We need to configure and enable all four of them.
+        let fmc_ref = &fmc.fmc;
+        configure_bcr1(&fmc_ref.bcr1);
+        configure_bcr(&fmc_ref.bcr2);
+        configure_bcr(&fmc_ref.bcr3);
+        configure_bcr(&fmc_ref.bcr4);
+        configure_btr(&fmc_ref.btr1, read_timing);
+        configure_btr(&fmc_ref.btr2, read_timing);
+        configure_btr(&fmc_ref.btr3, read_timing);
+        configure_btr(&fmc_ref.btr4, read_timing);
+        configure_bwtr(&fmc_ref.bwtr1, write_timing);
+        configure_bwtr(&fmc_ref.bwtr2, write_timing);
+        configure_bwtr(&fmc_ref.bwtr3, write_timing);
+        configure_bwtr(&fmc_ref.bwtr4, write_timing);
+
+        (FmcLcd { pins, fmc }, PINS::Lcds::conjure())
+    }
+
+    /// Reunites this FmcLcd and all its associated LCDs, and returns the FMC and pins for other
+    /// uses
+    pub fn release(self, _lcds: PINS::Lcds) -> (fmc::FMC, PINS) {
+        (self.fmc, self.pins)
+    }
+}
+
+/// Configures an SRAM/NOR-Flash chip-select control register for LCD interface use
+fn configure_bcr1(bcr: &pac::fmc::BCR1) {
+    bcr.write(|w| {
+        w
+            // The write fifo and WFDIS bit are missing from some models.
+            // Where present, the FIFO is enabled by default.
+            // ------------
+            // Disable synchronous writes
+            .cburstrw()
+            .disabled()
+            // Don't split burst transactions (doesn't matter for LCD mode)
+            .cpsize()
+            .no_burst_split()
+            // Ignore wait signal (asynchronous mode)
+            .asyncwait()
+            .disabled()
+            // Enable extended mode, for different read and write timings
+            .extmod()
+            .enabled()
+            // Ignore wait signal (synchronous mode)
+            .waiten()
+            .disabled()
+            // Allow write operations
+            .wren()
+            .enabled()
+            // Default wait timing
+            .waitcfg()
+            .before_wait_state()
+            // Default wait polarity
+            .waitpol()
+            .active_low()
+            // Disable burst reads
+            .bursten()
+            .disabled()
+            // Enable NOR flash operations
+            .faccen()
+            .enabled()
+            // 16-bit bus width
+            .mwid()
+            .bits16()
+            // NOR flash mode (compatible with LCD controllers)
+            .mtyp()
+            .flash()
+            // Address and data not multiplexed
+            .muxen()
+            .disabled()
+            // Enable this memory bank
+            .mbken()
+            .enabled()
+    })
+}
+
+/// Configures an SRAM/NOR-Flash chip-select control register for LCD interface use
+///
+/// This is equivalent to `configure_bcr1`, but without the `WFDIS` and `CCLKEN` bits that are
+/// present in BCR1 only.
+fn configure_bcr(bcr: &pac::fmc::BCR) {
+    bcr.write(|w| {
+        w
+            // Disable synchronous writes
+            .cburstrw()
+            .disabled()
+            // Don't split burst transactions (doesn't matter for LCD mode)
+            .cpsize()
+            .no_burst_split()
+            // Ignore wait signal (asynchronous mode)
+            .asyncwait()
+            .disabled()
+            // Enable extended mode, for different read and write timings
+            .extmod()
+            .enabled()
+            // Ignore wait signal (synchronous mode)
+            .waiten()
+            .disabled()
+            // Allow write operations
+            .wren()
+            .enabled()
+            // Default wait timing
+            .waitcfg()
+            .before_wait_state()
+            // Default wait polarity
+            .waitpol()
+            .active_low()
+            // Disable burst reads
+            .bursten()
+            .disabled()
+            // Enable NOR flash operations
+            .faccen()
+            .enabled()
+            // 16-bit bus width
+            .mwid()
+            .bits16()
+            // NOR flash mode (compatible with LCD controllers)
+            .mtyp()
+            .flash()
+            // Address and data not multiplexed
+            .muxen()
+            .disabled()
+            // Enable this memory bank
+            .mbken()
+            .enabled()
+    })
+}
+
+/// Configures a read timing register
+fn configure_btr(btr: &pac::fmc::BTR, read_timing: &Timing) {
+    btr.write(|w| unsafe {
+        w.accmod()
+            .variant(read_timing.access_mode.as_read_variant())
+            .busturn()
+            .bits(read_timing.bus_turnaround)
+            .datast()
+            .bits(read_timing.data)
+            .addhld()
+            .bits(read_timing.address_hold)
+            .addset()
+            .bits(read_timing.address_setup)
+    })
+}
+/// Configures a write timing register
+fn configure_bwtr(bwtr: &pac::fmc::BWTR, write_timing: &Timing) {
+    bwtr.write(|w| unsafe {
+        w.accmod()
+            .variant(write_timing.access_mode.as_write_variant())
+            .busturn()
+            .bits(write_timing.bus_turnaround)
+            .datast()
+            .bits(write_timing.data)
+            .addhld()
+            .bits(write_timing.address_hold)
+            .addset()
+            .bits(write_timing.address_setup)
+    })
+}
+
+/// An interface to an LCD controller using one sub-bank
+///
+/// This struct provides low-level read and write commands that can be used to implement
+/// drivers for LCD controllers. Each function corresponds to exactly one transaction on the bus.
+pub struct Lcd<S> {
+    /// Phantom S
+    ///
+    /// S determines the chip select signal to use, and the addresses used with that signal.
+    _sub_bank: PhantomData<S>,
+}
+
+impl<S> Lcd<S>
+where
+    S: SubBank,
+{
+    /// Writes a value with the data/command (address) signals set high
+    pub fn write_data(&mut self, value: u16) {
+        unsafe {
+            core::ptr::write_volatile(S::DATA_ADDRESS as *mut u16, value);
+        }
+    }
+
+    /// Writes a value with the data/command (address) signals set low
+    pub fn write_command(&mut self, value: u16) {
+        unsafe {
+            core::ptr::write_volatile(S::COMMAND_ADDRESS as *mut u16, value);
+        }
+    }
+
+    /// Reads a value with the data/command (address) signals set high
+    pub fn read_data(&self) -> u16 {
+        unsafe { core::ptr::read_volatile(S::DATA_ADDRESS as *const u16) }
+    }
+
+    /// Reads a value with the data/command (address) signals set low
+    pub fn read_command(&self) -> u16 {
+        unsafe { core::ptr::read_volatile(S::COMMAND_ADDRESS as *const u16) }
+    }
+}

--- a/src/fmc_lcd/pins.rs
+++ b/src/fmc_lcd/pins.rs
@@ -1,0 +1,714 @@
+//! Pin definitions for the Flexible Memory Controller
+//!
+//! Note: This file only includes pins for these functions:
+//! * NOE (read enable)
+//! * NWE (write enable)
+//! * NEx (chip select)
+//! * Ax (address)
+//! * Dx (data 0 through 15)
+//!
+//! # Naming conventions
+//!
+//! For signal names, this module uses:
+//! * Chip select instead of enable
+//! * Address instead of data/command
+//! * Read enable instead of output enable
+//! * Write enable
+
+use core::marker::PhantomData;
+
+use super::sealed;
+use super::{Lcd, SubBank1};
+use crate::fmc_lcd::{SubBank2, SubBank3, SubBank4};
+
+/// A pin that can be used for data bus 0
+pub trait PinD0: sealed::Sealed {}
+/// A pin that can be used for data bus 1
+pub trait PinD1: sealed::Sealed {}
+/// A pin that can be used for data bus 2
+pub trait PinD2: sealed::Sealed {}
+/// A pin that can be used for data bus 3
+pub trait PinD3: sealed::Sealed {}
+/// A pin that can be used for data bus 4
+pub trait PinD4: sealed::Sealed {}
+/// A pin that can be used for data bus 5
+pub trait PinD5: sealed::Sealed {}
+/// A pin that can be used for data bus 6
+pub trait PinD6: sealed::Sealed {}
+/// A pin that can be used for data bus 7
+pub trait PinD7: sealed::Sealed {}
+/// A pin that can be used for data bus 8
+pub trait PinD8: sealed::Sealed {}
+/// A pin that can be used for data bus 9
+pub trait PinD9: sealed::Sealed {}
+/// A pin that can be used for data bus 10
+pub trait PinD10: sealed::Sealed {}
+/// A pin that can be used for data bus 11
+pub trait PinD11: sealed::Sealed {}
+/// A pin that can be used for data bus 12
+pub trait PinD12: sealed::Sealed {}
+/// A pin that can be used for data bus 13
+pub trait PinD13: sealed::Sealed {}
+/// A pin that can be used for data bus 14
+pub trait PinD14: sealed::Sealed {}
+/// A pin that can be used for data bus 15
+pub trait PinD15: sealed::Sealed {}
+
+/// A pin that can be used for the output enable (read enable, NOE) signal
+pub trait PinReadEnable: sealed::Sealed {}
+/// A pin that can be used for the write enable (NOE) signal
+pub trait PinWriteEnable: sealed::Sealed {}
+/// A pin that can be used as one bit of the memory address
+///
+/// This is used to switch between data and command mode.
+pub trait PinAddress: sealed::Sealed {}
+
+/// A pin that can be used to enable a memory device on sub-bank 1
+pub trait PinChipSelect1: sealed::Sealed {}
+/// A pin that can be used to enable a memory device on sub-bank 2
+pub trait PinChipSelect2: sealed::Sealed {}
+/// A pin that can be used to enable a memory device on sub-bank 3
+pub trait PinChipSelect3: sealed::Sealed {}
+/// A pin that can be used to enable a memory device on sub-bank 4
+pub trait PinChipSelect4: sealed::Sealed {}
+
+/// One, two, three, or four address pins
+pub trait AddressPins: sealed::Sealed {}
+
+// Implement AddressPins for one address pin and tuples of two, three, and four
+impl<A> AddressPins for A where A: PinAddress {}
+impl<A1: PinAddress, A2: PinAddress> AddressPins for (A1, A2) {}
+impl<A1: PinAddress, A2: PinAddress> sealed::Sealed for (A1, A2) {}
+impl<A1: PinAddress, A2: PinAddress, A3: PinAddress> AddressPins for (A1, A2, A3) {}
+impl<A1: PinAddress, A2: PinAddress, A3: PinAddress> sealed::Sealed for (A1, A2, A3) {}
+impl<A1: PinAddress, A2: PinAddress, A3: PinAddress, A4: PinAddress> AddressPins
+    for (A1, A2, A3, A4)
+{
+}
+impl<A1: PinAddress, A2: PinAddress, A3: PinAddress, A4: PinAddress> sealed::Sealed
+    for (A1, A2, A3, A4)
+{
+}
+
+// Implement Conjure for all non-empty subsets of Lcds
+impl sealed::Conjure for Lcd<SubBank1> {
+    fn conjure() -> Self {
+        Lcd {
+            _sub_bank: PhantomData,
+        }
+    }
+}
+impl sealed::Conjure for Lcd<SubBank2> {
+    fn conjure() -> Self {
+        Lcd {
+            _sub_bank: PhantomData,
+        }
+    }
+}
+impl sealed::Conjure for Lcd<SubBank3> {
+    fn conjure() -> Self {
+        Lcd {
+            _sub_bank: PhantomData,
+        }
+    }
+}
+impl sealed::Conjure for Lcd<SubBank4> {
+    fn conjure() -> Self {
+        Lcd {
+            _sub_bank: PhantomData,
+        }
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank2>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank3>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank2>, Lcd<SubBank3>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank2>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank3>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank2>, Lcd<SubBank3>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank2>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank3>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank2>, Lcd<SubBank3>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+impl sealed::Conjure for (Lcd<SubBank1>, Lcd<SubBank2>, Lcd<SubBank3>, Lcd<SubBank4>) {
+    fn conjure() -> Self {
+        (
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+            Lcd {
+                _sub_bank: PhantomData,
+            },
+        )
+    }
+}
+
+/// One, two, three, or four chip select pins
+///
+/// Due to trait system limitations, this trait is only implemented for pins wrapped in the
+/// `ChipSelect1`, `ChipSelect2`, `ChipSelect3`, and `ChipSelect4` wrappers.
+///
+/// This trait is implemented for all non-empty subsets of the 4 possible chip select signals.
+/// The pins must be in order.
+///
+/// # Example types that implement `ChipSelectPins`
+///
+/// Wrapped single pins:
+/// * `ChipSelect1<PD7<Alternate<12>>>`
+/// * `ChipSelect2<PG9<Alternate<12>>>`
+/// * `ChipSelect3<PG10<Alternate<12>>>`
+/// * `ChipSelect4<PG12<Alternate<12>>>`
+///
+/// Tuples of wrapped pins:
+/// * `(ChipSelect1<PD7<Alternate<12>>>, ChipSelect2<PG9<Alternate<12>>>)`
+/// * `(ChipSelect1<PD7<Alternate<12>>>, ChipSelect4<PG4<Alternate<12>>>)`
+/// * `(ChipSelect1<PD7<Alternate<12>>>, ChipSelect2<PG9<Alternate<12>>>, ChipSelect3<PG10<Alternate<12>>>, ChipSelect4<PG12<Alternate<12>>>)`
+pub trait ChipSelectPins: sealed::Sealed {
+    /// One, two, three, or four `Lcd<_>` objects associated with the sub-bank(s) that these pin(s)
+    /// control
+    type Lcds: sealed::Conjure;
+}
+
+// The set of 4 chip selects has 15 subsets (excluding the empty set):
+// 1
+// 2
+// 3
+// 4
+// 1, 2
+// 1, 3
+// 1, 4
+// 2, 3
+// 2, 4
+// 3, 4
+// 1, 2, 3
+// 1, 2, 4
+// 1, 3, 4
+// 2, 3, 4
+// 1, 2, 3, 4
+
+/// Wrapper for a pin that implements PinChipSelect1
+///
+/// This is required to avoid conflicting trait implementations.
+pub struct ChipSelect1<P>(pub P);
+/// Wrapper for a pin that implements PinChipSelect2
+///
+/// This is required to avoid conflicting trait implementations.
+pub struct ChipSelect2<P>(pub P);
+/// Wrapper for a pin that implements PinChipSelect3
+///
+/// This is required to avoid conflicting trait implementations.
+pub struct ChipSelect3<P>(pub P);
+/// Wrapper for a pin that implements PinChipSelect4
+///
+/// This is required to avoid conflicting trait implementations.
+pub struct ChipSelect4<P>(pub P);
+
+impl<CS1: PinChipSelect1> ChipSelectPins for ChipSelect1<CS1> {
+    type Lcds = Lcd<SubBank1>;
+}
+impl<CS1: PinChipSelect1> sealed::Sealed for ChipSelect1<CS1> {}
+impl<CS2: PinChipSelect2> ChipSelectPins for ChipSelect2<CS2> {
+    type Lcds = Lcd<SubBank2>;
+}
+impl<CS2: PinChipSelect2> sealed::Sealed for ChipSelect2<CS2> {}
+impl<CS3: PinChipSelect3> ChipSelectPins for ChipSelect3<CS3> {
+    type Lcds = Lcd<SubBank3>;
+}
+impl<CS3: PinChipSelect3> sealed::Sealed for ChipSelect3<CS3> {}
+impl<CS4: PinChipSelect4> ChipSelectPins for ChipSelect4<CS4> {
+    type Lcds = Lcd<SubBank4>;
+}
+impl<CS4: PinChipSelect4> sealed::Sealed for ChipSelect4<CS4> {}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2> ChipSelectPins
+    for (ChipSelect1<CS1>, ChipSelect2<CS2>)
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank2>);
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2> sealed::Sealed
+    for (ChipSelect1<CS1>, ChipSelect2<CS2>)
+{
+}
+impl<CS1: PinChipSelect1, CS3: PinChipSelect3> ChipSelectPins
+    for (ChipSelect1<CS1>, ChipSelect3<CS3>)
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank3>);
+}
+impl<CS1: PinChipSelect1, CS3: PinChipSelect3> sealed::Sealed
+    for (ChipSelect1<CS1>, ChipSelect3<CS3>)
+{
+}
+impl<CS1: PinChipSelect1, CS4: PinChipSelect4> ChipSelectPins
+    for (ChipSelect1<CS1>, ChipSelect4<CS4>)
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank4>);
+}
+impl<CS1: PinChipSelect1, CS4: PinChipSelect4> sealed::Sealed
+    for (ChipSelect1<CS1>, ChipSelect4<CS4>)
+{
+}
+impl<CS2: PinChipSelect2, CS3: PinChipSelect3> ChipSelectPins
+    for (ChipSelect2<CS2>, ChipSelect3<CS3>)
+{
+    type Lcds = (Lcd<SubBank2>, Lcd<SubBank3>);
+}
+impl<CS2: PinChipSelect2, CS3: PinChipSelect3> sealed::Sealed
+    for (ChipSelect2<CS2>, ChipSelect3<CS3>)
+{
+}
+impl<CS2: PinChipSelect2, CS4: PinChipSelect4> ChipSelectPins
+    for (ChipSelect2<CS2>, ChipSelect4<CS4>)
+{
+    type Lcds = (Lcd<SubBank2>, Lcd<SubBank4>);
+}
+impl<CS2: PinChipSelect2, CS4: PinChipSelect4> sealed::Sealed
+    for (ChipSelect2<CS2>, ChipSelect4<CS4>)
+{
+}
+impl<CS3: PinChipSelect3, CS4: PinChipSelect4> ChipSelectPins
+    for (ChipSelect3<CS3>, ChipSelect4<CS4>)
+{
+    type Lcds = (Lcd<SubBank3>, Lcd<SubBank4>);
+}
+impl<CS3: PinChipSelect3, CS4: PinChipSelect4> sealed::Sealed
+    for (ChipSelect3<CS3>, ChipSelect4<CS4>)
+{
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2, CS3: PinChipSelect3> ChipSelectPins
+    for (ChipSelect1<CS1>, ChipSelect2<CS2>, ChipSelect3<CS3>)
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank2>, Lcd<SubBank3>);
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2, CS3: PinChipSelect3> sealed::Sealed
+    for (ChipSelect1<CS1>, ChipSelect2<CS2>, ChipSelect3<CS3>)
+{
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2, CS4: PinChipSelect4> ChipSelectPins
+    for (ChipSelect1<CS1>, ChipSelect2<CS2>, ChipSelect4<CS4>)
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank2>, Lcd<SubBank4>);
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2, CS4: PinChipSelect4> sealed::Sealed
+    for (ChipSelect1<CS1>, ChipSelect2<CS2>, ChipSelect4<CS4>)
+{
+}
+impl<CS1: PinChipSelect1, CS3: PinChipSelect3, CS4: PinChipSelect4> ChipSelectPins
+    for (ChipSelect1<CS1>, ChipSelect3<CS3>, ChipSelect4<CS4>)
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank3>, Lcd<SubBank4>);
+}
+impl<CS1: PinChipSelect1, CS3: PinChipSelect3, CS4: PinChipSelect4> sealed::Sealed
+    for (ChipSelect1<CS1>, ChipSelect3<CS3>, ChipSelect4<CS4>)
+{
+}
+impl<CS2: PinChipSelect2, CS3: PinChipSelect3, CS4: PinChipSelect4> ChipSelectPins
+    for (ChipSelect2<CS2>, ChipSelect3<CS3>, ChipSelect4<CS4>)
+{
+    type Lcds = (Lcd<SubBank2>, Lcd<SubBank3>, Lcd<SubBank4>);
+}
+impl<CS2: PinChipSelect2, CS3: PinChipSelect3, CS4: PinChipSelect4> sealed::Sealed
+    for (ChipSelect2<CS2>, ChipSelect3<CS3>, ChipSelect4<CS4>)
+{
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2, CS3: PinChipSelect3, CS4: PinChipSelect4>
+    ChipSelectPins
+    for (
+        ChipSelect1<CS1>,
+        ChipSelect2<CS2>,
+        ChipSelect3<CS3>,
+        ChipSelect4<CS4>,
+    )
+{
+    type Lcds = (Lcd<SubBank1>, Lcd<SubBank2>, Lcd<SubBank3>, Lcd<SubBank4>);
+}
+impl<CS1: PinChipSelect1, CS2: PinChipSelect2, CS3: PinChipSelect3, CS4: PinChipSelect4>
+    sealed::Sealed
+    for (
+        ChipSelect1<CS1>,
+        ChipSelect2<CS2>,
+        ChipSelect3<CS3>,
+        ChipSelect4<CS4>,
+    )
+{
+}
+
+/// A set of data pins
+///
+/// Currently this trait is only implemented for tuples of 16 data pins. In the future,
+/// this driver may support 8-bit mode using 8 data pins.
+pub trait DataPins: sealed::Sealed {}
+
+impl<D0, D1, D2, D3, D4, D5, D6, D7, D8, D9, D10, D11, D12, D13, D14, D15> DataPins
+    for (
+        D0,
+        D1,
+        D2,
+        D3,
+        D4,
+        D5,
+        D6,
+        D7,
+        D8,
+        D9,
+        D10,
+        D11,
+        D12,
+        D13,
+        D14,
+        D15,
+    )
+where
+    D0: PinD0,
+    D1: PinD1,
+    D2: PinD2,
+    D3: PinD3,
+    D4: PinD4,
+    D5: PinD5,
+    D6: PinD6,
+    D7: PinD7,
+    D8: PinD8,
+    D9: PinD9,
+    D10: PinD10,
+    D11: PinD11,
+    D12: PinD12,
+    D13: PinD13,
+    D14: PinD14,
+    D15: PinD15,
+{
+}
+impl<D0, D1, D2, D3, D4, D5, D6, D7, D8, D9, D10, D11, D12, D13, D14, D15> sealed::Sealed
+    for (
+        D0,
+        D1,
+        D2,
+        D3,
+        D4,
+        D5,
+        D6,
+        D7,
+        D8,
+        D9,
+        D10,
+        D11,
+        D12,
+        D13,
+        D14,
+        D15,
+    )
+where
+    D0: PinD0,
+    D1: PinD1,
+    D2: PinD2,
+    D3: PinD3,
+    D4: PinD4,
+    D5: PinD5,
+    D6: PinD6,
+    D7: PinD7,
+    D8: PinD8,
+    D9: PinD9,
+    D10: PinD10,
+    D11: PinD11,
+    D12: PinD12,
+    D13: PinD13,
+    D14: PinD14,
+    D15: PinD15,
+{
+}
+
+/// A set of pins used to interface with an LCD
+///
+/// The `address` and `enable` fields can be individual pins, or tuples of 2, 3, or 4 pins.
+pub struct LcdPins<D, AD, NOE, NWE, NE> {
+    /// The 16-bit data bus
+    pub data: D,
+    /// Address pin(s) (data/command)
+    pub address: AD,
+    /// Output enable (read enable)
+    pub read_enable: NOE,
+    /// Write enable
+    pub write_enable: NWE,
+    /// Chip select / bank enable pin(s)
+    pub chip_select: NE,
+}
+
+/// A set of pins that can be used with the FMC
+///
+/// This trait is implemented for the `LcdPins` struct that contains 16 data pins, 1 through 4
+/// address pins, 1 through 4 chip select / bank enable pins, an output enable pin, and a write
+/// enable pin.
+pub trait Pins: sealed::Sealed {
+    /// One, two, three, or four `Lcd<_>` objects associated with the sub-bank(s) that the chip
+    /// select pin pin(s) control
+    type Lcds: sealed::Conjure;
+}
+
+impl<D, AD, NOE, NWE, NE> Pins for LcdPins<D, AD, NOE, NWE, NE>
+where
+    D: DataPins,
+    AD: AddressPins,
+    NOE: PinReadEnable,
+    NWE: PinWriteEnable,
+    NE: ChipSelectPins,
+{
+    type Lcds = NE::Lcds;
+}
+
+impl<D, AD, NOE, NWE, NE> sealed::Sealed for LcdPins<D, AD, NOE, NWE, NE>
+where
+    D: DataPins,
+    AD: AddressPins,
+    NOE: PinReadEnable,
+    NWE: PinWriteEnable,
+    NE: ChipSelectPins,
+{
+}
+
+/// Pins available on all STM32F7 models that have an FMC
+mod common_pins {
+    use super::sealed::Sealed;
+    use super::{
+        PinAddress, PinChipSelect1, PinChipSelect2, PinChipSelect3, PinChipSelect4, PinD0, PinD1,
+        PinD10, PinD11, PinD12, PinD13, PinD14, PinD15, PinD2, PinD3, PinD4, PinD5, PinD6, PinD7,
+        PinD8, PinD9, PinReadEnable, PinWriteEnable,
+    };
+    use crate::gpio::gpiod::{
+        PD0, PD1, PD10, PD11, PD12, PD13, PD14, PD15, PD4, PD5, PD7, PD8, PD9,
+    };
+    use crate::gpio::gpioe::{
+        PE10, PE11, PE12, PE13, PE14, PE15, PE2, PE3, PE4, PE5, PE6, PE7, PE8, PE9,
+    };
+    use crate::gpio::gpiof::{PF0, PF1, PF12, PF13, PF14, PF15, PF2, PF3, PF4, PF5};
+    use crate::gpio::gpiog::{PG0, PG1, PG10, PG12, PG13, PG2, PG3, PG4, PG5, PG9};
+    use crate::gpio::{AF12, Alternate};
+
+    // All FMC pins use AF12
+    type FmcAlternate = Alternate<AF12>;
+
+    impl PinD2 for PD0<FmcAlternate> {}
+    impl PinD3 for PD1<FmcAlternate> {}
+    impl PinReadEnable for PD4<FmcAlternate> {}
+    impl PinWriteEnable for PD5<FmcAlternate> {}
+    impl PinChipSelect1 for PD7<FmcAlternate> {}
+    impl Sealed for PD7<FmcAlternate> {}
+    impl PinD13 for PD8<FmcAlternate> {}
+    impl PinD14 for PD9<FmcAlternate> {}
+    impl PinD15 for PD10<FmcAlternate> {}
+    impl PinAddress for PD11<FmcAlternate> {}
+    impl Sealed for PD11<FmcAlternate> {}
+    impl PinAddress for PD12<FmcAlternate> {}
+    impl Sealed for PD12<FmcAlternate> {}
+    impl PinAddress for PD13<FmcAlternate> {}
+    impl Sealed for PD13<FmcAlternate> {}
+    impl PinD0 for PD14<FmcAlternate> {}
+    impl PinD1 for PD15<FmcAlternate> {}
+    impl PinAddress for PE2<FmcAlternate> {}
+    impl Sealed for PE2<FmcAlternate> {}
+    impl PinAddress for PE3<FmcAlternate> {}
+    impl Sealed for PE3<FmcAlternate> {}
+    impl PinAddress for PE4<FmcAlternate> {}
+    impl Sealed for PE4<FmcAlternate> {}
+    impl PinAddress for PE5<FmcAlternate> {}
+    impl Sealed for PE5<FmcAlternate> {}
+    impl PinAddress for PE6<FmcAlternate> {}
+    impl Sealed for PE6<FmcAlternate> {}
+    impl PinD4 for PE7<FmcAlternate> {}
+    impl PinD5 for PE8<FmcAlternate> {}
+    impl PinD6 for PE9<FmcAlternate> {}
+    impl PinD7 for PE10<FmcAlternate> {}
+    impl PinD8 for PE11<FmcAlternate> {}
+    impl PinD9 for PE12<FmcAlternate> {}
+    impl PinD10 for PE13<FmcAlternate> {}
+    impl PinD11 for PE14<FmcAlternate> {}
+    impl PinD12 for PE15<FmcAlternate> {}
+
+    impl PinAddress for PF0<FmcAlternate> {}
+    impl Sealed for PF0<FmcAlternate> {}
+    impl PinAddress for PF1<FmcAlternate> {}
+    impl Sealed for PF1<FmcAlternate> {}
+    impl PinAddress for PF2<FmcAlternate> {}
+    impl Sealed for PF2<FmcAlternate> {}
+    impl PinAddress for PF3<FmcAlternate> {}
+    impl Sealed for PF3<FmcAlternate> {}
+    impl PinAddress for PF4<FmcAlternate> {}
+    impl Sealed for PF4<FmcAlternate> {}
+    impl PinAddress for PF5<FmcAlternate> {}
+    impl Sealed for PF5<FmcAlternate> {}
+    impl PinAddress for PF12<FmcAlternate> {}
+    impl Sealed for PF12<FmcAlternate> {}
+    impl PinAddress for PF13<FmcAlternate> {}
+    impl Sealed for PF13<FmcAlternate> {}
+    impl PinAddress for PF14<FmcAlternate> {}
+    impl Sealed for PF14<FmcAlternate> {}
+    impl PinAddress for PF15<FmcAlternate> {}
+    impl Sealed for PF15<FmcAlternate> {}
+    impl PinAddress for PG0<FmcAlternate> {}
+    impl Sealed for PG0<FmcAlternate> {}
+    impl PinAddress for PG1<FmcAlternate> {}
+    impl Sealed for PG1<FmcAlternate> {}
+    impl PinAddress for PG2<FmcAlternate> {}
+    impl Sealed for PG2<FmcAlternate> {}
+    impl PinAddress for PG3<FmcAlternate> {}
+    impl Sealed for PG3<FmcAlternate> {}
+    impl PinAddress for PG4<FmcAlternate> {}
+    impl Sealed for PG4<FmcAlternate> {}
+    impl PinAddress for PG5<FmcAlternate> {}
+    impl Sealed for PG5<FmcAlternate> {}
+    impl PinChipSelect2 for PG9<FmcAlternate> {}
+    impl Sealed for PG9<FmcAlternate> {}
+    impl PinChipSelect3 for PG10<FmcAlternate> {}
+    impl Sealed for PG10<FmcAlternate> {}
+    impl PinChipSelect4 for PG12<FmcAlternate> {}
+    impl Sealed for PG12<FmcAlternate> {}
+    impl PinAddress for PG13<FmcAlternate> {}
+    impl Sealed for PG13<FmcAlternate> {}
+    // PG14<Alternate<12> can be used as address 25 (A25), but that pin is not available here.
+    // Because external addresses are in units of 16 bits, external address line 25 can never
+    // be high. The internal memory address would overflow into the next sub-bank.
+
+    // Sealed trait boilerplate
+    impl Sealed for PD0<FmcAlternate> {}
+    impl Sealed for PD1<FmcAlternate> {}
+    impl Sealed for PD4<FmcAlternate> {}
+    impl Sealed for PD5<FmcAlternate> {}
+    impl Sealed for PD8<FmcAlternate> {}
+    impl Sealed for PD9<FmcAlternate> {}
+    impl Sealed for PD10<FmcAlternate> {}
+    impl Sealed for PD14<FmcAlternate> {}
+    impl Sealed for PD15<FmcAlternate> {}
+
+    impl Sealed for PE7<FmcAlternate> {}
+    impl Sealed for PE8<FmcAlternate> {}
+    impl Sealed for PE9<FmcAlternate> {}
+    impl Sealed for PE10<FmcAlternate> {}
+    impl Sealed for PE11<FmcAlternate> {}
+    impl Sealed for PE12<FmcAlternate> {}
+    impl Sealed for PE13<FmcAlternate> {}
+    impl Sealed for PE14<FmcAlternate> {}
+    impl Sealed for PE15<FmcAlternate> {}
+}

--- a/src/fmc_lcd/pins.rs
+++ b/src/fmc_lcd/pins.rs
@@ -605,7 +605,7 @@ mod common_pins {
     };
     use crate::gpio::gpiof::{PF0, PF1, PF12, PF13, PF14, PF15, PF2, PF3, PF4, PF5};
     use crate::gpio::gpiog::{PG0, PG1, PG10, PG12, PG13, PG2, PG3, PG4, PG5, PG9};
-    use crate::gpio::{AF12, Alternate};
+    use crate::gpio::{Alternate, AF12};
 
     // All FMC pins use AF12
     type FmcAlternate = Alternate<AF12>;

--- a/src/fmc_lcd/sealed.rs
+++ b/src/fmc_lcd/sealed.rs
@@ -1,0 +1,33 @@
+/// Private implementation details used in the fmc_lcd module and the pins submodule
+
+pub trait Sealed {}
+
+/// Private supertrait of SubBank
+pub trait SealedSubBank {
+    /// The address of the beginning of this sub-bank's address space
+    const BASE_ADDRESS: usize;
+    /// The address in memory used to communicate with the LCD controller with the data/command
+    /// signal set to command (low)
+    const COMMAND_ADDRESS: usize = Self::BASE_ADDRESS;
+    /// The address in memory used to communicate with the LCD controller with the data/command
+    /// signal set to data (high)
+    const DATA_ADDRESS: usize = make_data_address(Self::BASE_ADDRESS);
+}
+
+/// A trait similar to Default, but private to this crate
+///
+/// This is used to create `Lcd` objects and tuples of `Lcd`s.
+pub trait Conjure {
+    /// Creates something out of thin air
+    fn conjure() -> Self;
+}
+
+/// Converts a command address into a data address
+///
+/// The data address will result in all external address signals being set high.
+const fn make_data_address(base: usize) -> usize {
+    // Bits 26 and 27 select the sub-bank, don't change them.
+    // Bits 25 through 1 become address signals 24 through 0, set these high.
+    // Bit 0 is not used with 16-bit addressing.
+    base | 0x3fffffe
+}

--- a/src/fmc_lcd/timing.rs
+++ b/src/fmc_lcd/timing.rs
@@ -1,0 +1,122 @@
+//! FMC timing
+
+use super::pac::fmc;
+
+/// Memory access modes
+///
+/// These define the general shape of a transaction and the meanings of some of the time fields.
+/// Refer to the microcontroller reference manual for more details.
+#[derive(Debug, Clone)]
+pub enum AccessMode {
+    ModeA,
+    ModeB,
+    ModeC,
+    ModeD,
+}
+
+impl AccessMode {
+    pub(crate) fn as_read_variant(&self) -> fmc::btr::ACCMOD_A {
+        use fmc::btr::ACCMOD_A;
+        match *self {
+            AccessMode::ModeA => ACCMOD_A::A,
+            AccessMode::ModeB => ACCMOD_A::B,
+            AccessMode::ModeC => ACCMOD_A::C,
+            AccessMode::ModeD => ACCMOD_A::D,
+        }
+    }
+    pub(crate) fn as_write_variant(&self) -> fmc::bwtr::ACCMOD_A {
+        use fmc::bwtr::ACCMOD_A;
+        match *self {
+            AccessMode::ModeA => ACCMOD_A::A,
+            AccessMode::ModeB => ACCMOD_A::B,
+            AccessMode::ModeC => ACCMOD_A::C,
+            AccessMode::ModeD => ACCMOD_A::D,
+        }
+    }
+}
+
+/// Timing configuration for reading or writing
+///
+/// A `Timing` object can be created using `Timing::default()` or `Default::default()`.
+///
+/// The default timing uses access mode C and the slowest possible timings, for maximum
+/// compatibility.
+///
+/// If the LCD controller and wiring allow, you can reduce the times to make transactions faster.
+///
+/// All time fields are in units of HCLK cycles.
+#[derive(Debug, Clone)]
+pub struct Timing {
+    pub(crate) access_mode: AccessMode,
+    pub(crate) bus_turnaround: u8,
+    pub(crate) data: u8,
+    pub(crate) address_hold: u8,
+    pub(crate) address_setup: u8,
+}
+
+impl Default for Timing {
+    /// Returns a conservative (slow) timing configuration with access mode C
+    fn default() -> Self {
+        Timing {
+            access_mode: AccessMode::ModeC,
+            bus_turnaround: Timing::BUS_TURNAROUND_MAX,
+            data: 255,
+            address_hold: Timing::ADDRESS_HOLD_MAX,
+            address_setup: Timing::ADDRESS_SETUP_MAX,
+        }
+    }
+}
+
+impl Timing {
+    /// Maximum allowed value of the bus turnaround time
+    pub const BUS_TURNAROUND_MAX: u8 = 15;
+    /// Minimum allowed value of the data phase time
+    pub const DATA_MIN: u8 = 1;
+    /// Maximum allowed value of the address hold time
+    pub const ADDRESS_HOLD_MIN: u8 = 1;
+    /// Maximum allowed value of the address hold time
+    pub const ADDRESS_HOLD_MAX: u8 = 15;
+    /// Maximum allowed value of the address setup time
+    pub const ADDRESS_SETUP_MAX: u8 = 15;
+
+    /// Sets the access mode
+    pub fn access_mode(self, access_mode: AccessMode) -> Self {
+        Timing {
+            access_mode,
+            ..self
+        }
+    }
+    /// Sets the bus turnaround time, in units of HCLK cycles
+    ///
+    /// This corresponds to the BUSTURN field of FMC_BTR or FMC_BWTR.
+    pub fn bus_turnaround(self, bus_turnaround: u8) -> Self {
+        Timing {
+            bus_turnaround,
+            ..self
+        }
+    }
+    /// Sets the data phase time, in units of HCLK cycles
+    ///
+    /// This corresponds to the DATAST field of FMC_BTR or FMC_BWTR.
+    pub fn data(self, data: u8) -> Self {
+        Timing { data, ..self }
+    }
+    /// Sets the address hold phase time, in units of HCLK cycles
+    ///
+    /// This corresponds to the ADDHLD field of FMC_BTR or FMC_BWTR.
+    pub fn address_hold(self, address_hold: u8) -> Self {
+        Timing {
+            address_hold,
+            ..self
+        }
+    }
+    /// Sets the address setup phase time, in units of HCLK cycles
+    ///
+    /// This corresponds to the ADDSET field of FMC_BTR or FMC_BWTR.
+    pub fn address_setup(self, address_setup: u8) -> Self {
+        Timing {
+            address_setup,
+            ..self
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@ pub mod dma;
 #[cfg(all(feature = "device-selected", feature = "fmc"))]
 pub mod fmc;
 
+#[cfg(all(feature = "fmc_lcd", feature = "device-selected", feature = "fmc"))]
+pub mod fmc_lcd;
+
 #[cfg(feature = "device-selected")]
 pub mod gpio;
 


### PR DESCRIPTION
A port (copy paste and refactor) of the code made in [PR #297 by samcrow](https://github.com/stm32-rs/stm32f4xx-hal/pull/297) to [stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal).

I ported this over because I needed FMC display functionality for an operating system for my calculator (https://github.com/willemml/rustworks).