### PR TITLE
Configure Git to ignore VS Code configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/*.orig
 **/*.rs.bk
 Cargo.lock
+
+# VS Code
+/.vscode


### PR DESCRIPTION
An alternative would be to add it to the repository, but that's probably
too opinionated, given this crate's wide variety of configurations.