### PR TITLE
Panic instead of entering endless loop on error

### DIFF
--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -343,7 +343,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
     /// Draw a pixel at position (x,y) on the given layer
     pub fn draw_pixel(&mut self, layer: Layer, x: usize, y: usize, color: T) {
         if x >= self.config.active_width as usize || y >= self.config.active_height as usize {
-            loop {}
+            panic!("Invalid (x,y) pixel position");
         }
 
         match layer {


### PR DESCRIPTION
It might be even better to return an explicit error, depending on how
the method is used, but a panic doesn't require changes to the method
signature and is a clear improvement.