### PR TITLE
Change Into<Hertz> to TryInto<Hertz> in rcc.rs

### DIFF
--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -22,7 +22,7 @@ fn main() -> ! {
     let rcc = p.RCC.constrain();
 
     // Configure clock and freeze it
-    let clocks = rcc.cfgr.sysclk(216_000_000.Hz()).freeze();
+    let clocks = rcc.cfgr.sysclk(216.MHz()).freeze();
 
     // Get delay provider
     let mut delay = Delay::new(cp.SYST, clocks);

--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -85,7 +85,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         // Get base clock and PLLM divisor
         let base_clk: u32;
         match &hse {
-            Some(hse) => base_clk = hse.freq,
+            Some(hse) => base_clk = hse.freq.0,
             // If no HSE is provided, we use the HSI clock at 16 MHz
             None => base_clk = 16_000_000,
         }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1094,6 +1094,8 @@ bus! {
 mod tests {
     use crate::prelude::*;
 
+    use crate::embedded_time::rate::Hertz;
+
     use super::{FreqRequest, CFGR};
 
     fn build_request(sysclk: u32, use_pll48clk: bool) -> FreqRequest {
@@ -1218,7 +1220,7 @@ mod tests {
             .sysclk(216_000_000.Hz());
         cfgr.pll_configure();
 
-        assert_eq!(cfgr.hse.unwrap().freq, 25_000_000);
+        assert_eq!(cfgr.hse.unwrap().freq, Hertz(25_000_000u32));
 
         let (clocks, _config) = cfgr.calculate_clocks();
         assert_eq!(clocks.sysclk().0, 216_000_000);
@@ -1249,7 +1251,7 @@ mod tests {
             .sysclk(216_000_000.Hz());
         cfgr.pll_configure();
 
-        assert_eq!(cfgr.hse.unwrap().freq, 25_000_000);
+        assert_eq!(cfgr.hse.unwrap().freq, Hertz(25_000_000u32));
 
         let (clocks, _config) = cfgr.calculate_clocks();
         assert_eq!(clocks.sysclk().0, 216_000_000);
@@ -1280,7 +1282,7 @@ mod tests {
             .set_defaults();
         cfgr.pll_configure();
 
-        assert_eq!(cfgr.hse.unwrap().freq, 25_000_000);
+        assert_eq!(cfgr.hse.unwrap().freq, Hertz(25_000_000u32));
 
         let (clocks, _config) = cfgr.calculate_clocks();
         assert_eq!(clocks.sysclk().0, 216_000_000);


### PR DESCRIPTION
In contrast to my suggestion in #136 I decided to change `Into<Hertz>` to `TryInto<Hertz>` in `rcc.rs`. All methods that take a frequency argument already contained assertions that would cause a panic if the value is out of range. The same assertions can also catch if `TryInto<Hertz>` fails.

I've also added some docs to make the user aware that these methods might panic and under which conditions.