### PR TITLE
RCC: Added note about reset of `use_pll` to false

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -343,6 +343,8 @@ impl CFGR {
     }
 
     /// Sets the SYSCLK clock source to the main PLL.
+    ///
+    /// Note: `sysclk` must be specified or `use_pll48clk` must be set to true, otherwise `use_pll` is reset to false.
     pub fn use_pll(mut self) -> Self {
         self.use_pll = true;
         self


### PR DESCRIPTION
Added note about reset of `use_pll` to false if `sysclk` or `use_pll48clk` is not set (`pll_configure` is called before `calculate_clocks`).

I ran into the problem that I specified `use_pll` and assumed that it would then calculate `sysclk`.