### PR TITLE
Add plli2s to CFGR struct

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -407,6 +407,7 @@ impl CFGR {
     }
 
     /// Sets the PLLI2SN multiplication factor for PLLI2S.
+    ///
     /// # Panics
     ///
     /// Panics if the multiplication factor isn't between 50 and 432.
@@ -417,6 +418,7 @@ impl CFGR {
     }
 
     /// Sets the PLLI2SQ division factor for PLLI2S.
+    ///
     /// # Panics
     ///
     /// Panics if the division factor isn't between 2 and 15.
@@ -427,6 +429,7 @@ impl CFGR {
     }
 
     /// Sets the PLLI2SR division factor for PLLI2S.
+    ///
     /// # Panics
     ///
     /// Panics if the division factor isn't between 2 and 7.


### PR DESCRIPTION
Add PLLI2S configuration based on PLL. Tested with a STM32F767.


Motivation:
Moving unsafe PLLI2S configuration and activation functions to the HAL.
For example:
``` rust
    p.RCC
        .plli2scfgr
        .modify(|_r, w| unsafe { w.plli2sn().bits(100).plli2sr().bits(2) });

    let hseclock = HSEClock::new(24.MHz(), HSEClockMode::Oscillator);
    let clocks = rcc
        .cfgr
        .hse(hseclock)
        .pllm(12)
        .plln(200)
        .pllp(stm32_eth::hal::rcc::PLLP::Div2)
        .use_pll()
        .sysclk(200.MHz())
        .freeze();
    
    unsafe {
        let rcc = &*stm32_eth::hal::pac::RCC::ptr();
        rcc.cr.modify(|_r, w| w.plli2son().on());
    }
```

Outcome:
``` rust
    let hseclock = HSEClock::new(24.MHz(), HSEClockMode::Oscillator);
    let clocks = rcc
        .cfgr
        .hse(hseclock)
        .pllm(12)
        .plln(200)
        .pllp(stm32_eth::hal::rcc::PLLP::Div2)
        .plli2sn(100)
        .plli2sr(2)
        .use_pll()
        .use_plli2s()
        .sysclk(200.MHz())
        .freeze();
```

Tests:
``` bash
$ cargo test --features=stm32f767 --target x86_64-unknown-linux-gnu --lib
    Finished test [unoptimized + debuginfo] target(s) in 0.03s
     Running unittests (target/x86_64-unknown-linux-gnu/debug/deps/stm32f7xx_hal-15a659e78bfcd155)

running 10 tests
test rcc::tests::test_pll_calc1_usb ... ok
test rcc::tests::test_pll_calc2_usb ... ok
test rcc::tests::test_pll_calc2 ... ok
test rcc::tests::test_pll_calc1 ... ok
test rcc::tests::test_pll_calc3 ... ok
test rcc::tests::test_rcc_calc2 ... ok
test rcc::tests::test_rcc_calc3 ... ok
test rcc::tests::test_rcc_default ... ok
test rcc::tests::test_rcc_calc1 ... ok
test rcc::tests::test_pll_calc3_usb ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s