### PR TITLE
Cargo: cortex-m "0.7", cortex-m-rt ">=0.6.15, <0.8", stm32f7 "0.14.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ features = ["stm32f746", "rt"]
 
 [dependencies]
 as-slice = "0.1.0"
-cortex-m = "0.6.0"
-cortex-m-rt = "0.6.8"
+cortex-m = "0.7"
+cortex-m-rt = ">=0.6.15, <0.8"
 embedded-time = "0.12.0"
 nb = "0.1.2"
 rtcc = "0.2"
-stm32f7 = "0.11.0"
+stm32f7 = "0.14.0"
 micromath = "1.0.0"
 synopsys-usb-otg = { version = "0.2.3", features = ["cortex-m"], optional = true }
 stm32-fmc = { version = "0.2.0", features = ["sdram"], optional = true }

--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -148,25 +148,25 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         while rcc.cr.read().pllsairdy().is_not_ready() {}
 
         // Configure LTDC Timing registers
-        ltdc.sscr.write(|w| unsafe {
+        ltdc.sscr.write(|w| {
             w.hsw()
                 .bits((config.h_sync - 1) as u16)
                 .vsh()
                 .bits((config.v_sync - 1) as u16)
         });
-        ltdc.bpcr.write(|w| unsafe {
+        ltdc.bpcr.write(|w| {
             w.ahbp()
                 .bits((config.h_sync + config.h_back_porch - 1) as u16)
                 .avbp()
                 .bits((config.v_sync + config.v_back_porch - 1) as u16)
         });
-        ltdc.awcr.write(|w| unsafe {
+        ltdc.awcr.write(|w| {
             w.aaw()
                 .bits((config.h_sync + config.h_back_porch + config.active_width - 1) as u16)
                 .aah()
                 .bits((config.v_sync + config.v_back_porch + config.active_height - 1) as u16)
         });
-        ltdc.twcr.write(|w| unsafe {
+        ltdc.twcr.write(|w| {
             w.totalw()
                 .bits(total_width as u16)
                 .totalh()
@@ -234,13 +234,13 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         let h_win_start = self.config.h_sync + self.config.h_back_porch - 1;
         let v_win_start = self.config.v_sync + self.config.v_back_porch - 1;
 
-        _layer.whpcr.write(|w| unsafe {
+        _layer.whpcr.write(|w| {
             w.whstpos()
                 .bits(h_win_start + 1)
                 .whsppos()
                 .bits(h_win_start + width)
         });
-        _layer.wvpcr.write(|w| unsafe {
+        _layer.wvpcr.write(|w| {
             w.wvstpos()
                 .bits(v_win_start + 1)
                 .wvsppos()
@@ -248,7 +248,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         });
 
         // Set pixel format
-        _layer.pfcr.write(|w| unsafe {
+        _layer.pfcr.write(|w| {
             w.pf().bits(match &pixel_format {
                 PixelFormat::ARGB8888 => 0b000,
                 // PixelFormat::RGB888 => 0b001,
@@ -263,7 +263,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         });
 
         // Set global alpha value to 1 (255/255). Used for layer blending.
-        _layer.cacr.write(|w| unsafe { w.consta().bits(0xFF) });
+        _layer.cacr.write(|w| w.consta().bits(0xFF));
 
         // Set default color to plain (not transparent) red (for debug
         // purposes). The default color is used outside the defined layer window
@@ -281,7 +281,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         // Color frame buffer start address
         _layer
             .cfbar
-            .write(|w| unsafe { w.cfbadd().bits(buffer.as_ptr() as u32) });
+            .write(|w| w.cfbadd().bits(buffer.as_ptr() as u32));
 
         // Color frame buffer line length (active*byte per pixel + 3), and pitch
         let byte_per_pixel: u16 = match &pixel_format {
@@ -295,7 +295,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
             PixelFormat::AL88 => 2,
             // _ => unimplemented!(),
         };
-        _layer.cfblr.write(|w| unsafe {
+        _layer.cfblr.write(|w| {
             w.cfbp()
                 .bits(width * byte_per_pixel)
                 .cfbll()
@@ -303,7 +303,7 @@ impl<T: 'static + SupportedWord> DisplayController<T> {
         });
 
         // Frame buffer number of lines
-        _layer.cfblnr.write(|w| unsafe { w.cfblnbr().bits(height) });
+        _layer.cfblnr.write(|w| w.cfblnbr().bits(height));
 
         // No Color Lookup table (CLUT)
         _layer.cr.modify(|_, w| w.cluten().clear_bit());

--- a/src/qspi.rs
+++ b/src/qspi.rs
@@ -125,7 +125,7 @@ impl Qspi {
                     )
                 };
 
-                let rx_transfer = rx_transfer.start(&dma);
+                let rx_transfer = rx_transfer.start(dma);
 
                 // Set DMA bit since we are using it
                 self.qspi.cr.modify(|_, w| w.dmaen().set_bit());
@@ -174,7 +174,7 @@ impl Qspi {
                     )
                 };
 
-                let tx_transfer = tx_transfer.start(&dma);
+                let tx_transfer = tx_transfer.start(dma);
 
                 // Set DMA bit since we are using it
                 self.qspi.cr.modify(|_, w| w.dmaen().set_bit());

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1096,8 +1096,8 @@ bus! {
     SPI5 => (APB2, spi5en, spi5rst),
 
     USART1 => (APB2, usart1en, usart1rst),
-    USART2 => (APB1, usart2en, uart2rst),
-    USART3 => (APB1, usart3en, uart3rst),
+    USART2 => (APB1, usart2en, usart2rst),
+    USART3 => (APB1, usart3en, usart3rst),
     UART4 => (APB1, uart4en, uart4rst),
     UART5 => (APB1, uart5en, uart5rst),
     USART6 => (APB2, usart6en, usart6rst),

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -60,7 +60,7 @@ impl Rtc {
             // Set 24 Hour
             regs.cr.modify(|_, w| w.fmt().clear_bit());
             // Set prescalers
-            regs.prer.modify(|_, w| unsafe {
+            regs.prer.modify(|_, w| {
                 w.prediv_s().bits(prediv_s);
                 w.prediv_a().bits(prediv_a)
             })
@@ -123,7 +123,7 @@ impl Rtcc for Rtc {
         let (mnt, mnu) = bcd2_encode(time.minute())?;
         let (st, su) = bcd2_encode(time.second())?;
         self.modify(|regs| {
-            regs.tr.write(|w| unsafe {
+            regs.tr.write(|w| {
                 w.ht().bits(ht);
                 w.hu().bits(hu);
                 w.mnt().bits(mnt);
@@ -142,10 +142,7 @@ impl Rtcc for Rtc {
             return Err(Error::InvalidInputData);
         }
         let (st, su) = bcd2_encode(seconds as u32)?;
-        self.modify(|regs| {
-            regs.tr
-                .modify(|_, w| unsafe { w.st().bits(st).su().bits(su) })
-        });
+        self.modify(|regs| regs.tr.modify(|_, w| w.st().bits(st).su().bits(su)));
 
         Ok(())
     }
@@ -155,10 +152,7 @@ impl Rtcc for Rtc {
             return Err(Error::InvalidInputData);
         }
         let (mnt, mnu) = bcd2_encode(minutes as u32)?;
-        self.modify(|regs| {
-            regs.tr
-                .modify(|_, w| unsafe { w.mnt().bits(mnt).mnu().bits(mnu) })
-        });
+        self.modify(|regs| regs.tr.modify(|_, w| w.mnt().bits(mnt).mnu().bits(mnu)));
 
         Ok(())
     }
@@ -170,10 +164,7 @@ impl Rtcc for Rtc {
             Hours::AM(_h) | Hours::PM(_h) => self.set_12h_fmt(),
         }
 
-        self.modify(|regs| {
-            regs.tr
-                .modify(|_, w| unsafe { w.ht().bits(ht).hu().bits(hu) })
-        });
+        self.modify(|regs| regs.tr.modify(|_, w| w.ht().bits(ht).hu().bits(hu)));
 
         Ok(())
     }
@@ -192,10 +183,7 @@ impl Rtcc for Rtc {
             return Err(Error::InvalidInputData);
         }
         let (dt, du) = bcd2_encode(day as u32)?;
-        self.modify(|regs| {
-            regs.dr
-                .modify(|_, w| unsafe { w.dt().bits(dt).du().bits(du) })
-        });
+        self.modify(|regs| regs.dr.modify(|_, w| w.dt().bits(dt).du().bits(du)));
 
         Ok(())
     }
@@ -205,10 +193,7 @@ impl Rtcc for Rtc {
             return Err(Error::InvalidInputData);
         }
         let (mt, mu) = bcd2_encode(month as u32)?;
-        self.modify(|regs| {
-            regs.dr
-                .modify(|_, w| unsafe { w.mt().bit(mt > 0).mu().bits(mu) })
-        });
+        self.modify(|regs| regs.dr.modify(|_, w| w.mt().bit(mt > 0).mu().bits(mu)));
 
         Ok(())
     }
@@ -218,10 +203,7 @@ impl Rtcc for Rtc {
             return Err(Error::InvalidInputData);
         }
         let (yt, yu) = bcd2_encode(year as u32 - 1970)?;
-        self.modify(|regs| {
-            regs.dr
-                .modify(|_, w| unsafe { w.yt().bits(yt).yu().bits(yu) })
-        });
+        self.modify(|regs| regs.dr.modify(|_, w| w.yt().bits(yt).yu().bits(yu)));
 
         Ok(())
     }
@@ -238,7 +220,7 @@ impl Rtcc for Rtc {
         let (dt, du) = bcd2_encode(date.day())?;
 
         self.modify(|regs| {
-            regs.dr.write(|w| unsafe {
+            regs.dr.write(|w| {
                 w.dt().bits(dt);
                 w.du().bits(du);
                 w.mt().bit(mt > 0);
@@ -266,7 +248,7 @@ impl Rtcc for Rtc {
         let (st, su) = bcd2_encode(date.second())?;
 
         self.modify(|regs| {
-            regs.dr.write(|w| unsafe {
+            regs.dr.write(|w| {
                 w.dt().bits(dt);
                 w.du().bits(du);
                 w.mt().bit(mt > 0);
@@ -274,7 +256,7 @@ impl Rtcc for Rtc {
                 w.yt().bits(yt);
                 w.yu().bits(yu)
             });
-            regs.tr.write(|w| unsafe {
+            regs.tr.write(|w| {
                 w.ht().bits(ht);
                 w.hu().bits(hu);
                 w.mnt().bits(mnt);


### PR DESCRIPTION
Motivation:
Adapt dependencies following the f4-hal to upgrade [stm32-eth crate](https://github.com/stm32-rs/stm32-eth).

Bump cortex-m from 0.6.0 to 0.7.
Bump cortex-m-rt from 0.6.8 to ">=0.6.15, <0.8"
Bump stm32f7 from 0.11.0 to 0.14.0

Tested with a STM32F767.