### PR TITLE
Fix RAM address and add ITCM and DTCM sections

### DIFF
--- a/memory_2048_368.x
+++ b/memory_2048_368.x
@@ -3,8 +3,31 @@ MEMORY
 {
   /* NOTE K = KiBi = 1024 bytes */
   FLASH : ORIGIN = 0x08000000, LENGTH = 2M
-  RAM : ORIGIN = 0x20000000, LENGTH = 368K + 16K
+  RAM : ORIGIN = 0x20020000, LENGTH = 368K + 16K
+  ITCM : ORIGIN = 0x00000000, LENGTH = 16K /* Instruction Tighly Coupled Memory */
+  DTCM : ORIGIN = 0x20000000, LENGTH = 128K /* Data Tighly Coupled Memory */
 }
+
+SECTIONS
+{
+    .itcm : ALIGN(4)
+    {
+        *(.itcm .itcm.*);
+        . = ALIGN(4);
+    } > ITCM
+
+    .dtcm : ALIGN(4)
+    {
+        *(.dtcm .dtcm.*);
+        . = ALIGN(4);
+    } > DTCM
+}
+
+/* You can then use something like this to place a variable into a specific section of memory:
+ *  #[link_section = ".dtcm.BUFFER"]
+ *  static mut BUF: [u8; 1024] = [3u8; 1024];
+ *  Verifiable with: cargo size --release --example hello_world -- -A
+ */
 
 /* This is where the call stack will be allocated. */
 /* The stack is of the full descending type. */


### PR DESCRIPTION
Previously DTCM region was simply added to RAM region, this can cause problems with DMA as DMA does not have access to DTCM region.
See page 71 and 76 in reference manual RM0410, Rev 4.

Also https://github.com/stm32-rs/stm32f7xx-hal/issues/123

Signed-off-by: Moritz Scheuren <moritz.scheuren@systec-electronic.com>

edit by @hannobraun: Make sure we "close #123" automatically once this merges.