### PR TITLE
RTC: Rewritten

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ cortex-m = "0.7"
 cortex-m-rt = ">=0.6.15, <0.8"
 embedded-time = "0.12.0"
 nb = "1.0"
-rtcc = "0.2"
 stm32f7 = "0.14.0"
 micromath = "2.0"
 synopsys-usb-otg = { version = "0.2.3", features = ["cortex-m"], optional = true }
@@ -28,6 +27,10 @@ stm32-fmc = { version = "0.2.0", features = ["sdram"], optional = true }
 rand_core = "0.6"
 bxcan = "0.6"
 bare-metal = "1.0"
+
+[dependencies.time]
+version = "0.3"
+default-features = false
 
 [dependencies.cast]
 default-features = false
@@ -52,6 +55,11 @@ panic-semihosting = "0.5.2"
 embedded-graphics = "0.6.1"
 usb-device = "0.2.5"
 usbd-serial = "0.1.0"
+
+[dev-dependencies.time]
+version = "0.3"
+default-features = false
+features = ["macros"]
 
 [features]
 device-selected = []

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -9,11 +9,14 @@ extern crate panic_halt as _;
 use cortex_m_rt::entry;
 
 use cortex_m_semihosting::hprintln;
-use rtcc::{Hours, NaiveDate, NaiveTime, Rtcc};
 use stm32f7xx_hal::{
     pac,
     prelude::*,
     rtc::{Rtc, RtcClock},
+};
+use time::{
+    macros::{date, time},
+    PrimitiveDateTime,
 };
 
 #[entry]
@@ -34,21 +37,19 @@ fn main() -> ! {
     )
     .unwrap();
 
-    rtc.set_24h_fmt();
-    rtc.set_time(&NaiveTime::from_hms(12, 30, 00)).unwrap();
-    rtc.set_date(&NaiveDate::from_ymd(2021, 11, 25)).unwrap();
+    rtc.set_datetime(&PrimitiveDateTime::new(date!(2019 - 01 - 01), time!(23:59)))
+        .unwrap();
+    // Alternatively:
+    // rtc.set_date(&date!(2019 - 01 - 01)).unwrap();
+    // rtc.set_time(&time!(23:59)).unwrap();
+    // Or:
+    // rtc.set_year(2019).unwrap();
+    // rtc.set_month(12).unwrap();
+    // rtc.set_day(31).unwrap();
+    // rtc.set_hours(23).unwrap();
+    // rtc.set_minutes(59).unwrap();
+    // rtc.set_seconds(59).unwrap();
     loop {
-        if let Hours::H24(h) = rtc.get_hours().unwrap() {
-            hprintln!(
-                "{}-{}-{} {}:{}:{}",
-                rtc.get_year().unwrap(),
-                rtc.get_month().unwrap(),
-                rtc.get_day().unwrap(),
-                h,
-                rtc.get_minutes().unwrap(),
-                rtc.get_seconds().unwrap()
-            )
-            .unwrap();
-        }
+        hprintln!("{}", rtc.get_datetime()).unwrap();
     }
 }


### PR DESCRIPTION
* Removed rtcc in favor of time
* Removed get functions in favor of a single get_datetime function
* Takes into account registers synchronization flag
* Always returns a valid time (or panics)
* Removed disgusting 12-hour format support (Which wasn't implemented consistent anyway)

See https://github.com/stm32-rs/stm32f7xx-hal/pull/160#issuecomment-988792463 from @adamgreig.

> Instead of returning an error, maybe it would be nicer to perform a second read and so always return consistent data?
>
> The RM says (in RM0385 29.3.8 Reading the calendar) that if the APB clock is >= 7x the RTC clock (which is very likely since RTC clock is usually 32kHz) then it's OK to just read TR and then DR: the hardware locks DR after you read TR to ensure you get consistent data. In fact, it's important to always read TR and then DR, otherwise the later read of TR will lock an old value of DR. But, even if the APB clock is extremely slow, you can always read TR, then DR, then TR, then DR, and use the first values if the two TRs match, or the second values if the TRs don't match (as also described in the RM). Seems friendlier than returning an error to the user who has no choice but to now re-read in a loop until it doesn't error.
>
> It looks like the driver should also wait for RSF to be set before taking values in case the user re-reads very soon afterwards too, and clear it after each read. Maybe it would be best to have a single get_datetime() method that does the correct wait-for-RSF, read TR, read DR, clear RSF sequence, and parses the fields, and then convenience methods for reading just seconds/minutes/etc could call that and return the relevant bit. Or just always give the user a full consistent datetime to make sure they don't try and read each part separately and end up with inconsistent data that way anyway...