### PR TITLE
Add support for flash.rs on bigger chips

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -180,9 +180,7 @@ impl<'a> EraseSequence<'a> {
                 feature = "stm32f778",
                 feature = "stm32f779",
             ))]
-            w
-                .mer1().clear_bit()
-                .mer2().clear_bit();
+            w.mer1().clear_bit().mer2().clear_bit();
             #[cfg(not(any(
                 feature = "stm32f765",
                 feature = "stm32f767",
@@ -192,9 +190,7 @@ impl<'a> EraseSequence<'a> {
                 feature = "stm32f779",
             )))]
             w.mer().clear_bit();
-            w
-                .ser().set_bit()
-                .snb().bits(sector_number)
+            w.ser().set_bit().snb().bits(sector_number)
         });
         flash.registers.cr.modify(|_, w| w.strt().start());
 
@@ -215,9 +211,7 @@ impl<'a> EraseSequence<'a> {
                 feature = "stm32f778",
                 feature = "stm32f779",
             ))]
-            w
-                .mer1().set_bit()
-                .mer2().set_bit();
+            w.mer1().set_bit().mer2().set_bit();
             #[cfg(not(any(
                 feature = "stm32f765",
                 feature = "stm32f767",
@@ -227,10 +221,9 @@ impl<'a> EraseSequence<'a> {
                 feature = "stm32f779",
             )))]
             w.mer().clear_bit();
-            w
-                .ser().clear_bit()
+            w.ser().clear_bit()
         });
-                
+
         flash.registers.cr.modify(|_, w| w.strt().start());
 
         Ok(Self { flash })

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -172,12 +172,29 @@ impl<'a> EraseSequence<'a> {
         //TODO: This should check if sector_number is valid for this device
 
         flash.registers.cr.modify(|_, w| unsafe {
-            w.mer()
-                .clear_bit()
-                .ser()
-                .set_bit()
-                .snb()
-                .bits(sector_number)
+            #[cfg(any(
+                feature = "stm32f765",
+                feature = "stm32f767",
+                feature = "stm32f769",
+                feature = "stm32f777",
+                feature = "stm32f778",
+                feature = "stm32f779",
+            ))]
+            w
+                .mer1().clear_bit()
+                .mer2().clear_bit();
+            #[cfg(not(any(
+                feature = "stm32f765",
+                feature = "stm32f767",
+                feature = "stm32f769",
+                feature = "stm32f777",
+                feature = "stm32f778",
+                feature = "stm32f779",
+            )))]
+            w.mer().clear_bit();
+            w
+                .ser().set_bit()
+                .snb().bits(sector_number)
         });
         flash.registers.cr.modify(|_, w| w.strt().start());
 
@@ -189,10 +206,31 @@ impl<'a> EraseSequence<'a> {
         flash.check_locked_or_busy()?;
         flash.clear_errors();
 
-        flash
-            .registers
-            .cr
-            .modify(|_, w| w.mer().set_bit().ser().clear_bit());
+        flash.registers.cr.modify(|_, w| unsafe {
+            #[cfg(any(
+                feature = "stm32f765",
+                feature = "stm32f767",
+                feature = "stm32f769",
+                feature = "stm32f777",
+                feature = "stm32f778",
+                feature = "stm32f779",
+            ))]
+            w
+                .mer1().set_bit()
+                .mer2().set_bit();
+            #[cfg(not(any(
+                feature = "stm32f765",
+                feature = "stm32f767",
+                feature = "stm32f769",
+                feature = "stm32f777",
+                feature = "stm32f778",
+                feature = "stm32f779",
+            )))]
+            w.mer().clear_bit();
+            w
+                .ser().clear_bit()
+        });
+                
         flash.registers.cr.modify(|_, w| w.strt().start());
 
         Ok(Self { flash })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,17 +160,7 @@ pub mod qei;
 #[cfg(feature = "ltdc")]
 pub mod ltdc;
 
-#[cfg(all(
-    feature = "device-selected",
-    not(any(
-        feature = "stm32f765",
-        feature = "stm32f767",
-        feature = "stm32f769",
-        feature = "stm32f777",
-        feature = "stm32f778",
-        feature = "stm32f779",
-    ))
-))]
+#[cfg(feature = "device-selected")]
 pub mod flash;
 
 pub mod state {


### PR DESCRIPTION
The current code to erase flash is only using the `mer` field.
On bigger chips, there is two memory banks, so the `mer` field is split in two for the two memory banks, `mer1` and `mer2`.

This PR add checks to configure either `mer` or `mer[12]` for erase functions.