### PR TITLE
Serial parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,10 @@ name = "serial_echo"
 required-features = ["stm32f746", "rt"]
 
 [[example]]
+name = "serial_parity"
+required-features = ["stm32f767", "rt"]
+
+[[example]]
 name = "stm32f7disco-screen"
 required-features = ["stm32f746", "rt"]
 

--- a/examples/serial_delay.rs
+++ b/examples/serial_delay.rs
@@ -43,6 +43,7 @@ fn main() -> ! {
             oversampling: serial::Oversampling::By16,
             character_match: None,
             sysclock: false,
+            parity: serial::Parity::ParityNone,
         },
     );
     let (mut tx, _) = serial.split();

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -51,6 +51,7 @@ fn main() -> ! {
             oversampling: serial::Oversampling::By16,
             character_match: None,
             sysclock: false,
+            parity: serial::Parity::ParityNone,
         },
     );
     let (mut tx, mut rx) = serial.split();

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -40,6 +40,7 @@ fn main() -> ! {
             oversampling: serial::Oversampling::By16,
             character_match: None,
             sysclock: false,
+            parity: serial::Parity::ParityNone,
         },
     );
 

--- a/examples/serial_parity.rs
+++ b/examples/serial_parity.rs
@@ -23,7 +23,9 @@ fn main() -> ! {
     let p = pac::Peripherals::take().unwrap();
 
     let rcc = p.RCC.constrain();
-    let clocks = rcc.cfgr.sysclk(216_000_000.Hz()).freeze();
+    let clocks = rcc.cfgr.sysclk(48.MHz()).freeze();
+
+    let mut delay = p.TIM5.delay_ms(&clocks);
 
     let gpiod = p.GPIOD.split();
 
@@ -50,6 +52,8 @@ fn main() -> ! {
     loop {
         block!(tx.write(byte)).ok();
 
-        byte += 1;
+        byte = byte.wrapping_add(1);
+
+        delay.delay(10.millis());
     }
 }

--- a/examples/serial_parity.rs
+++ b/examples/serial_parity.rs
@@ -1,0 +1,55 @@
+//! Write characters to the serial port with parity.
+//!
+//! Note: This example is for the STM32F767
+
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use nb::block;
+
+use cortex_m_rt::entry;
+use stm32f7xx_hal::{
+    pac,
+    prelude::*,
+    serial::{self, Serial},
+};
+
+#[entry]
+fn main() -> ! {
+    let p = pac::Peripherals::take().unwrap();
+
+    let rcc = p.RCC.constrain();
+    let clocks = rcc.cfgr.sysclk(216_000_000.Hz()).freeze();
+
+    let gpiod = p.GPIOD.split();
+
+    let tx = gpiod.pd5.into_alternate();
+    let rx = gpiod.pd6.into_alternate();
+
+    let serial = Serial::new(
+        p.USART2,
+        (tx, rx),
+        &clocks,
+        serial::Config {
+            baud_rate: 56_700.bps(),
+            oversampling: serial::Oversampling::By16,
+            character_match: None,
+            sysclock: false,
+            parity: serial::Parity::ParityEven,
+        },
+    );
+
+    let (mut tx, mut _rx) = serial.split();
+
+    let mut byte: u8 = 0;
+
+    loop {
+        block!(tx.write(byte)).ok();
+
+        byte += 1;
+    }
+}


### PR DESCRIPTION
hi stm32f7 folks! :peacock: 

here's a pull request to port serial parity from [stm32h7xx-hal](https://github.com/stm32-rs/stm32h7xx-hal/blob/5983983/src/serial.rs).

since we only read and write 8-bit words, when we add a parity bit, we need to update the stm32f7 serial words to 9-bits.

i also added a basic example for my own testing, but can be removed.

cheers :sunflower: 