### PR TITLE
Serial data bits and default config for serial examples

### DIFF
--- a/examples/serial_delay.rs
+++ b/examples/serial_delay.rs
@@ -39,11 +39,8 @@ fn main() -> ! {
         (tx, rx),
         &clocks,
         serial::Config {
-            baud_rate: 115_200.bps(),
-            oversampling: serial::Oversampling::By16,
-            character_match: None,
-            sysclock: false,
-            parity: serial::Parity::ParityNone,
+            // Default to 115_200 bauds
+            ..Default::default()
         },
     );
     let (mut tx, _) = serial.split();

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -47,11 +47,8 @@ fn main() -> ! {
         (tx, rx),
         &clocks,
         serial::Config {
-            baud_rate: 115_200.bps(),
-            oversampling: serial::Oversampling::By16,
-            character_match: None,
-            sysclock: false,
-            parity: serial::Parity::ParityNone,
+            // Default to 115_200 bauds
+            ..Default::default()
         },
     );
     let (mut tx, mut rx) = serial.split();

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -36,11 +36,8 @@ fn main() -> ! {
         (tx, rx),
         &clocks,
         serial::Config {
-            baud_rate: 115_200.bps(),
-            oversampling: serial::Oversampling::By16,
-            character_match: None,
-            sysclock: false,
-            parity: serial::Parity::ParityNone,
+            // Default to 115_200 bauds
+            ..Default::default()
         },
     );
 

--- a/examples/serial_parity.rs
+++ b/examples/serial_parity.rs
@@ -15,7 +15,7 @@ use cortex_m_rt::entry;
 use stm32f7xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Serial},
+    serial::{self, Serial, DataBits},
 };
 
 #[entry]
@@ -37,11 +37,11 @@ fn main() -> ! {
         (tx, rx),
         &clocks,
         serial::Config {
-            baud_rate: 56_700.bps(),
-            oversampling: serial::Oversampling::By16,
-            character_match: None,
-            sysclock: false,
-            parity: serial::Parity::ParityEven,
+            // Using 8 bits of data + 1 for even parity
+            data_bits: DataBits::Bits9,
+            parity: Parity::ParityEven,
+            // Default to 115_200 bauds
+            ..Default::default()
         },
     );
 

--- a/examples/serial_parity.rs
+++ b/examples/serial_parity.rs
@@ -15,7 +15,7 @@ use cortex_m_rt::entry;
 use stm32f7xx_hal::{
     pac,
     prelude::*,
-    serial::{self, Serial, DataBits},
+    serial::{self, Serial, DataBits, Parity},
 };
 
 #[entry]


### PR DESCRIPTION
Following #181 to add control over parity on UARTs, adding control of data bits.
Also using default config in examples to avoid having to change them every time there is a modification in the config structure.