### PR TITLE
Add config for VSCode rust-analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 **/*.orig
 **/*.rs.bk
 Cargo.lock
-
-# VS Code
-/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "rust.all_targets": false,
+    "rust.target": "thumbv7em-none-eabihf",
+    "rust.all_features": false,
+    "rust.features": [
+      "rtic",
+      "stm32f767"
+    ],
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.checkOnSave.extraArgs": [
+        "--target",
+        "thumbv7em-none-eabihf"
+    ],
+    "rust-analyzer.cargo.features": [
+      "rtic",
+      "stm32f767"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This crate is largely inspired by the awesome work done here:
 - [embedded-hal](https://github.com/japaric/embedded-hal.git)
 - [stm32f4](https://crates.io/crates/stm32f4)
 
+## VSCode
+
+Default settings for `rust-analyzer` are set in [.vscode/settings.json](.vscode/settings.json) for `stm32f767`. If you're working on another chip, you can change the target there for convenience, but don't commit your change to this file.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
`rust-analyzer` on VSCode requires selecting a MCU feature to run.

This PR adds a default config with some info in the README to tell user to change it.