### PR TITLE
README: rewrite based on stm32f1xx-hal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,59 @@
 # `stm32f7xx-hal`
 
+> [HAL] for the STM32F7 family of microcontrollers
+
+[HAL]: https://crates.io/crates/embedded-hal
+
 [![Crates.io - stm32f7xx-hal](https://img.shields.io/crates/v/stm32f7xx-hal.svg?maxAge=2592000)](https://crates.io/crates/stm32f7xx-hal)
 [![Released API docs](https://docs.rs/stm32f7xx-hal/badge.svg)](https://docs.rs/stm32f7xx-hal)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/stm32-rs/stm32f7xx-hal/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/stm32-rs/stm32f7xx-hal/actions)
 
-A Rust embedded-hal HAL for all MCUs in the STM32 F7 family.
-
 This crate is largely inspired by the awesome work done here:
 
-- [stm32f767-hal](https://github.com/therealprof/stm32f767-hal)
-- [stm32f103xx-hal](https://github.com/japaric/stm32f103xx-hal)
-- [embedded-hal](https://github.com/japaric/embedded-hal.git)
-- [stm32f4](https://crates.io/crates/stm32f4)
+- [stm32f1xx-hal](https://github.com/stm32-rs/stm32f1xx-hal)
+- [stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal)
+
+## Selecting a microcontroller
+
+This crate supports multiple microcontrollers in the
+stm32f7 family. Which specific microcontroller you want to build for has to be
+specified with a feature, for example `stm32f767`. 
+
+If no microcontroller is specified, the crate will not compile.
+
+### Supported Microcontrollers
+
+* `stm32f722`
+* `stm32f723`
+* `stm32f730`
+* `stm32f732`
+* `stm32f733`
+* `stm32f745`
+* `stm32f746`
+* `stm32f756`
+* `stm32f765`
+* `stm32f767`
+* `stm32f769`
+* `stm32f777`
+* `stm32f778`
+* `stm32f779`
+
+## Using as a Dependency
+
+When using this crate as a dependency in your project, the microcontroller can 
+be specified as part of the `Cargo.toml` definition.
+
+```toml
+[dependencies.stm32f7xx-hal]
+version = "0.7.0"
+features = ["stm32f767", "rt"]
+```
+
+## Documentation
+
+The documentation can be found at [docs.rs/stm32f7xx-hal](https://docs.rs/stm32f7xx-hal/).
 
 ## License
 


### PR DESCRIPTION
Since the current README is a bit empty and not really up to date anymore concerning the main sources of inspiration, this PR refresh that a bit, based on the [stm32f1xx-hal](https://github.com/stm32-rs/stm32f1xx-hal).
Ideally it'd be nice to have some examples on how to use this lib like for the above-mentionned HAL, but setting up `probe-run` as default runner first might get us a more accessible and up-to-date environment to write that on top off.