### PR TITLE
Small documentation updates

### DIFF
--- a/src/dac.rs
+++ b/src/dac.rs
@@ -1,3 +1,5 @@
+//! Digital-to-analog converter
+
 use crate::pac::DAC;
 use crate::{
     gpio::{

--- a/src/ltdc.rs
+++ b/src/ltdc.rs
@@ -1,3 +1,5 @@
+//! Interface to the LCD-TFT display controller
+
 #[cfg_attr(test, allow(unused_imports))]
 use micromath::F32Ext;
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,3 +1,5 @@
+//! Interface to the true random number generator
+
 use core::cmp;
 use core::mem;
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,4 +1,4 @@
-//! Interface to the real time clock. See STM32F303 reference manual, section 27.
+//! Interface to the real time clock.
 //! For more details, see
 //! [ST AN4759](https://www.st.com/resource/en/application_note/an4759-using-the-hardware-realtime-clock-rtc-and-the-tamper-management-unit-tamp-with-stm32-microcontrollers-stmicroelectronics.pdf)
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,6 +1,6 @@
 //! Interface to the real time clock. See STM32F303 reference manual, section 27.
 //! For more details, see
-//! [ST AN4759](https:/www.st.com%2Fresource%2Fen%2Fapplication_note%2Fdm00226326-using-the-hardware-realtime-clock-rtc-and-the-tamper-management-unit-tamp-with-stm32-microcontrollers-stmicroelectronics.pdf&usg=AOvVaw3PzvL2TfYtwS32fw-Uv37h)
+//! [ST AN4759](https://www.st.com/resource/en/application_note/an4759-using-the-hardware-realtime-clock-rtc-and-the-tamper-management-unit-tamp-with-stm32-microcontrollers-stmicroelectronics.pdf)
 
 use crate::pac::rtc::{dr, tr};
 use crate::pac::{PWR, RCC, RTC};

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,3 +1,5 @@
+//! Serial communication using UART/USART peripherals
+
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::Deref;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,3 +1,5 @@
+//! Interface to the timer peripherals
+
 #![allow(non_upper_case_globals)]
 
 use core::convert::TryFrom;


### PR DESCRIPTION
This fixes a broken link in the rtc-docstring, as well as removing the reference to F303 section 27

Also, while I was at it, I added a short docstring to the modules that didn't have it, so the module index on the docs front page looks a little nicer
