### PR TITLE
Bump bxcan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ micromath = "2.0"
 synopsys-usb-otg = { version = "0.2.3", features = ["cortex-m"], optional = true }
 stm32-fmc = { version = "0.2.0", features = ["sdram"], optional = true }
 rand_core = "0.6"
-bxcan = "0.6"
+bxcan = "0.7"
 bare-metal = "1.0"
 fugit = "0.3.5"
 fugit-timer = "0.1.3"

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -4,6 +4,7 @@
 #![no_main]
 #![no_std]
 
+use bxcan::Fifo::Fifo0;
 use panic_halt as _;
 
 use bxcan::filter::Mask32;
@@ -50,7 +51,7 @@ fn main() -> ! {
 
     // Configure filters so that can frames can be received.
     let mut filters = can1.modify_filters();
-    filters.enable_bank(0, Mask32::accept_all());
+    filters.enable_bank(0, Fifo0, Mask32::accept_all());
 
     let _can2 = {
         let rx = gpiob.pb5.into_alternate();
@@ -68,11 +69,11 @@ fn main() -> ! {
         // Split them equally between CAN1 and CAN2.
         filters.set_split(14);
         let mut slave_filters = filters.slave_filters();
-        slave_filters.enable_bank(14, Mask32::accept_all());
+        slave_filters.enable_bank(14, Fifo0, Mask32::accept_all());
         can2
     };
 
-    // Drop filters to leave filter configuraiton mode.
+    // Drop filters to leave filter configuration mode.
     drop(filters);
 
     // Select the interface.
@@ -80,8 +81,6 @@ fn main() -> ! {
     //let mut can = can2;
 
     // Echo back received packages in sequence.
-    // See the `can-rtfm` example for an echo implementation that adheres to
-    // correct frame ordering based on the transfer id.
     loop {
         if let Ok(frame) = block!(can.receive()) {
             block!(can.transmit(&frame)).unwrap();

--- a/examples/can-loopback.rs
+++ b/examples/can-loopback.rs
@@ -4,6 +4,7 @@
 #![no_main]
 #![no_std]
 
+use bxcan::Fifo::Fifo0;
 use bxcan::{
     filter::{ListEntry16, ListEntry32, Mask16},
     ExtendedId, Frame, StandardId,
@@ -57,9 +58,9 @@ fn main() -> ! {
     // of the `split_filters_advanced()` method.
 
     // 2x 11bit id + mask filter bank: Matches 0, 1, 2
-    // TODO: Make this accept also ID 2
     filters.enable_bank(
         0,
+        Fifo0,
         [
             // accepts 0 and 1
             Mask16::frames_with_std_id(StandardId::new(0).unwrap(), StandardId::new(1).unwrap()),
@@ -71,6 +72,7 @@ fn main() -> ! {
     // 2x 29bit id filter bank: Matches 4, 5
     filters.enable_bank(
         1,
+        Fifo0,
         [
             ListEntry32::data_frames_with_id(ExtendedId::new(4).unwrap()),
             ListEntry32::data_frames_with_id(ExtendedId::new(5).unwrap()),
@@ -80,6 +82,7 @@ fn main() -> ! {
     // 4x 11bit id filter bank: Matches 8, 9, 10, 11
     filters.enable_bank(
         2,
+        Fifo0,
         [
             ListEntry16::data_frames_with_id(StandardId::new(8).unwrap()),
             ListEntry16::data_frames_with_id(StandardId::new(9).unwrap()),
@@ -88,7 +91,7 @@ fn main() -> ! {
         ],
     );
 
-    // Drop filters to leave filter configuraiton mode.
+    // Drop filters to leave filter configuration mode.
     drop(filters);
 
     // Some messages shall pass the filters.


### PR DESCRIPTION
Bxcan is on v0.6 here, v0.7 adds embedded-hal traits, which cannot be used with this crate since it is on v0.6. 

This PR simply updates bxcan.