### PR TITLE
examples: blink-timer-irq: fix clock panic

### DIFF
--- a/examples/blinky-timer-irq.rs
+++ b/examples/blinky-timer-irq.rs
@@ -67,7 +67,7 @@ fn main() -> ! {
     let dp = Peripherals::take().unwrap();
 
     let rcc = dp.RCC.constrain();
-    let clocks = rcc.cfgr.sysclk(16.MHz()).pclk1(8.MHz()).freeze();
+    let clocks = rcc.cfgr.sysclk(16.MHz()).pclk1(13.MHz()).freeze();
 
     // Configure PA5 pin to blink LED
     let gpioa = dp.GPIOA.split();


### PR DESCRIPTION
The example sets the frequency of the pclk1 to an out-of-bounds frequency which causes the example to panic in all instancies.

Set to a frequency that is in-range.

Tested on: STM32F746G-DISCO