### PR TITLE
Enabled interruptable gpio on alternate function pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Use PascalCase for generated values of enums ([stm32-rs#727](https://github.com/stm32-rs/stm32-rs/pull/727))
 - Updated `synopsys-usb-otg` dependency 0.2.3 -> 0.3
 - Updated `stm32-fmc` dependency 0.2.0 -> 0.3
+- Added Interruptable trait to Alternate mode pins
 
 ## [v0.7.0] - 2022-06-05
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -150,6 +150,7 @@ mod sealed {
 use sealed::Interruptable;
 impl<MODE> Interruptable for Output<MODE> {}
 impl<MODE> Interruptable for Input<MODE> {}
+impl<const A: u8, MODE> Interruptable for Alternate<A, MODE> {}
 
 /// External Interrupt Pin
 pub trait ExtiPin {


### PR DESCRIPTION
I noticed while trying to use the `ExtiPin` trait on an `Alternate` function pin that the `ExtiPin` trait wasn't enabled. Based on [examples from other STM32 hals](https://github.com/stm32-rs/stm32f4xx-hal/blob/43a97678f8772af1712fec3af7b3391cf02f6ba6/src/gpio.rs#L173) I impl'd the trait. It appears to work correctly on my STM32F723.

closes https://github.com/stm32-rs/stm32f7xx-hal/issues/198
