### PR TITLE
Fix build.rs / lib.rs after b497ddec

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -88,7 +88,7 @@ impl SubFamily {
             SubFamily::Stm32f722
         } else if cfg!(feature = "stm32f723") {
             SubFamily::Stm32f723
-        } else if cfg!(feature = "stm32f730") {
+        } else if cfg!(feature = "stm32f730") || cfg!(feature = "stm32f730-lpc") {
             SubFamily::Stm32f730
         } else if cfg!(feature = "stm32f732") {
             SubFamily::Stm32f732

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ compile_error!(
         stm32f722
         stm32f723
         stm32f730
+        stm32f730-lpc
         stm32f732
         stm32f733
         stm32f745
@@ -31,7 +32,7 @@ pub use stm32f7::stm32f7x2 as pac;
 #[cfg(feature = "stm32f723")]
 pub use stm32f7::stm32f7x3 as pac;
 
-#[cfg(feature = "stm32f730")]
+#[cfg(any(feature = "stm32f730", feature = "stm32f730-lpc"))]
 pub use stm32f7::stm32f730 as pac;
 
 #[cfg(feature = "stm32f732")]
@@ -95,6 +96,7 @@ pub mod dac;
         feature = "stm32f722",
         feature = "stm32f723",
         feature = "stm32f730",
+        feature = "stm32f730-lpc",
         feature = "stm32f732",
         feature = "stm32f733",
         feature = "stm32f746",
@@ -109,6 +111,7 @@ pub mod otg_fs;
         feature = "stm32f722",
         feature = "stm32f723",
         feature = "stm32f730",
+        feature = "stm32f730-lpc",
         feature = "stm32f732",
         feature = "stm32f733",
         feature = "stm32f746",


### PR DESCRIPTION
I never actually tried to build.  :-/  Add support for the -lpc variant to build.rs and the module definitions in lib.rs.