### PR TITLE
fix: compilation on nightly

### DIFF
--- a/src/flash.rs
+++ b/src/flash.rs
@@ -202,7 +202,7 @@ impl<'a> EraseSequence<'a> {
         flash.check_locked_or_busy()?;
         flash.clear_errors();
 
-        flash.registers.cr.modify(|_, w| unsafe {
+        flash.registers.cr.modify(|_, w| {
             #[cfg(any(
                 feature = "stm32f765",
                 feature = "stm32f767",

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -189,10 +189,7 @@ where
 
         // Enable tx / rx, configure data bits and parity
         usart.cr1.modify(|_, w| {
-            w
-                .te().enabled()
-                .re().enabled()
-                .ue().enabled();
+            w.te().enabled().re().enabled().ue().enabled();
 
             // M[1:0] are used to set data bits
             // M[1:0] = 00: 1 Start bit, 8 data bits, n stop bits
@@ -206,7 +203,7 @@ where
 
             match config.parity {
                 Parity::ParityEven => w.ps().even().pce().enabled(),
-                Parity::ParityOdd  => w.ps().odd().pce().enabled(),
+                Parity::ParityOdd => w.ps().odd().pce().enabled(),
                 Parity::ParityNone => w.pce().disabled(),
             }
         });
@@ -444,7 +441,7 @@ where
         if isr.txe().bit_is_set() {
             // NOTE(unsafe) atomic write to stateless register
             // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
-            unsafe { ptr::write_volatile(&(*U::ptr()).tdr as *const _ as *mut _, byte) }
+            unsafe { ptr::write_volatile(core::ptr::addr_of!((*U::ptr()).tdr) as *mut u8, byte) }
             Ok(())
         } else {
             Err(nb::Error::WouldBlock)
@@ -460,7 +457,6 @@ pub struct Config {
     pub sysclock: bool,
     pub parity: Parity,
     pub data_bits: DataBits,
-
 }
 
 pub enum Oversampling {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -386,9 +386,7 @@ macro_rules! impl_instance {
                         // to access it. This is safe, as `&self.dr` is a
                         // memory-mapped register.
                         let value = unsafe {
-                            ptr::read_volatile(
-                                &self.dr as *const _ as *const _,
-                            )
+                            ptr::read_volatile(self.dr_address() as *mut _)
                         };
 
                         return Ok(value);
@@ -424,7 +422,7 @@ macro_rules! impl_instance {
                         // memory-mapped register.
                         unsafe {
                             ptr::write_volatile(
-                                &self.dr as *const _ as *mut _,
+                                self.dr_address() as *mut _,
                                 word,
                             );
                         }
@@ -436,7 +434,7 @@ macro_rules! impl_instance {
                 }
 
                 fn dr_address(&self) -> u32 {
-                    &self.dr as *const _ as _
+                    core::ptr::addr_of!(self.dr) as u32
                 }
             }
 


### PR DESCRIPTION
This fixes a bug when casting a *const _ to *mut _ on nightly, it's being phased out as acceptable and is now a hard error :grimacing: 

I could be completely wrong in my fix, but the compiler is happy - also, I noticed in spi.rs that the comment about writing 8 bits vs 16 bits mattered - I couldn't find anything about that in any manual for the f769 (board I have) but I could have easily missed something there.

Any feedback is appreciated!