### PR TITLE
Add SPI2_SCK pin for stm32f769i-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated `stm32-fmc` dependency 0.2.0 -> 0.3
 - Added Interruptable trait to Alternate mode pins
 - Added a "low pin count" variant of the f730 chip to the crate features: packages <144 pins don't include a high speed USB PHY
+- Added SPI2_SCK pin for stm32f769i-discovery
 
 ## [v0.7.0] - 2022-06-05
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -479,6 +479,7 @@ impl_instance!(
         pins: {
             SCK: [
                 gpio::PA9<Alternate<5>>,
+                gpio::PA12<Alternate<5>>,
                 gpio::PB10<Alternate<5>>,
                 gpio::PB13<Alternate<5>>,
                 gpio::PD3<Alternate<5>>,


### PR DESCRIPTION
Hi,

On stm32f769i-discovery, the pin for SPI2_SCK is PA12, as described in https://www.st.com/resource/en/user_manual/dm00276557.pdf, section 6.2.

It'll be nice if this pin can be added.

Thank you.