### PR TITLE
Fix mass-erase trigger on "small" devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added Interruptable trait to Alternate mode pins
 - Added a "low pin count" variant of the f730 chip to the crate features: packages <144 pins don't include a high speed USB PHY
 - Added SPI2_SCK pin for stm32f769i-discovery
+- Fix mass-erase triggering in `flash` on smaller chips
 
 ## [v0.7.0] - 2022-06-05
 

--- a/examples/serial_dma.rs
+++ b/examples/serial_dma.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
     // function won't return as long as the program runs, so there's no chance
     // of anyone else using the same static.
     static mut BUFFER: [u8; 4] = [0; 4];
-    let mut buffer = unsafe { Pin::new(&mut BUFFER) };
+    let mut buffer = unsafe { Pin::new(&mut *core::ptr::addr_of_mut!(BUFFER)) };
     loop {
         // Read using DMA
         let mut transfer = rx.read_all(buffer, &dma, rx_stream);

--- a/examples/spi_dma.rs
+++ b/examples/spi_dma.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
     // function won't return as long as the program runs, so there's no chance
     // of anyone else using the same static.
     static mut BUFFER: [u8; 2] = [0; 2];
-    let mut buffer = unsafe { Pin::new(&mut BUFFER) };
+    let mut buffer = unsafe { Pin::new(&mut *core::ptr::addr_of_mut!(BUFFER)) };
 
     loop {
         // Read WHO_AM_I register of an MPU9250 sensor.

--- a/examples/spi_dma_16.rs
+++ b/examples/spi_dma_16.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
     // function won't return as long as the program runs, so there's no chance
     // of anyone else using the same static.
     static mut BUFFER: [u16; 1] = [0; 1];
-    let mut buffer = unsafe { Pin::new(&mut BUFFER) };
+    let mut buffer = unsafe { Pin::new(&mut *core::ptr::addr_of_mut!(BUFFER)) };
 
     // Use a button to control output via the Maxim Integrated MAX5214 DAC.
     loop {

--- a/examples/stm32f7disco-qspi-flash/main.rs
+++ b/examples/stm32f7disco-qspi-flash/main.rs
@@ -123,8 +123,8 @@ fn memory_example_dma(
 
     // Create pinned versions for DMA transfers
     let mut stream = stream;
-    let mut read_buffer = unsafe { Pin::new(&mut READ_BUFFER) };
-    let mut page_buffer = unsafe { Pin::new(&mut PAGE_BUFFER) };
+    let mut read_buffer = unsafe { Pin::new(&mut *core::ptr::addr_of_mut!(READ_BUFFER)) };
+    let mut page_buffer = unsafe { Pin::new(&mut *core::ptr::addr_of_mut!(PAGE_BUFFER)) };
 
     ///////////////////////
     // Test erase + read //

--- a/examples/stm32f7disco-screen/main.rs
+++ b/examples/stm32f7disco-screen/main.rs
@@ -103,7 +103,7 @@ fn main() -> ! {
     let mut display = screen::Stm32F7DiscoDisplay::new(perif.LTDC, perif.DMA2D);
     display
         .controller
-        .config_layer(Layer::L1, unsafe { &mut FB_LAYER1 }, PixelFormat::RGB565);
+        .config_layer(Layer::L1, unsafe { &mut *core::ptr::addr_of_mut!(FB_LAYER1) }, PixelFormat::RGB565);
 
     display.controller.enable_layer(Layer::L1);
     display.controller.reload();

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -220,7 +220,7 @@ impl<'a> EraseSequence<'a> {
                 feature = "stm32f778",
                 feature = "stm32f779",
             )))]
-            w.mer().clear_bit();
+            w.mer().set_bit();
             w.ser().clear_bit()
         });
 


### PR DESCRIPTION
The list of specifically enumerated "large" devices has the correct set of register operations to start a mass erase, setting the mer1 and mer2 bits.  But the "small-devices" alternative does not; it clears the mer bit instead of setting it.

Looking at history, this was changed from set to clear in the PR that added support for "large" devices.  It appears to have been accidental.