### PR TITLE
Fix the addresses of `signature` module structs for some devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Use the right addresses for `signature` module structs on f7x2, f7x3, and f730 devices
+
 ## [0.8.0] - 2024-08-02
 
 ### Changed

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -30,6 +30,9 @@ pub struct Uid {
     y: u16,
     waf_lot: [u8; 8],
 }
+#[cfg(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730"))]
+define_ptr_type!(Uid, 0x1FF0_7A10);
+#[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(Uid, 0x1FF0_F420);
 
 impl Uid {
@@ -58,6 +61,9 @@ impl Uid {
 #[derive(Debug)]
 #[repr(C)]
 pub struct FlashSize(u16);
+#[cfg(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730"))]
+define_ptr_type!(FlashSize, 0x1FF0_7A22);
+#[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(FlashSize, 0x1FF0_F442);
 
 impl FlashSize {
@@ -76,6 +82,7 @@ impl FlashSize {
 #[derive(Debug)]
 #[repr(C)]
 pub struct VrefCal(u16);
+#[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(VrefCal, 0x1FF0_F44A);
 
 impl VrefCal {
@@ -89,6 +96,7 @@ impl VrefCal {
 #[derive(Debug)]
 #[repr(C)]
 pub struct VtempCal30(u16);
+#[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(VtempCal30, 0x1FF0_F44C);
 
 impl VtempCal30 {
@@ -102,6 +110,7 @@ impl VtempCal30 {
 #[derive(Debug)]
 #[repr(C)]
 pub struct VtempCal110(u16);
+#[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(VtempCal110, 0x1FF0_F44E);
 
 impl VtempCal110 {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -82,6 +82,8 @@ impl FlashSize {
 #[derive(Debug)]
 #[repr(C)]
 pub struct VrefCal(u16);
+#[cfg(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730"))]
+define_ptr_type!(VrefCal, 0x1FF0_7A2A);
 #[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(VrefCal, 0x1FF0_F44A);
 
@@ -96,6 +98,8 @@ impl VrefCal {
 #[derive(Debug)]
 #[repr(C)]
 pub struct VtempCal30(u16);
+#[cfg(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730"))]
+define_ptr_type!(VtempCal30, 0x1FF0_7A2C);
 #[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(VtempCal30, 0x1FF0_F44C);
 
@@ -110,6 +114,8 @@ impl VtempCal30 {
 #[derive(Debug)]
 #[repr(C)]
 pub struct VtempCal110(u16);
+#[cfg(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730"))]
+define_ptr_type!(VtempCal110, 0x1FF0_7A2E);
 #[cfg(not(any(feature = "svd-f7x2", feature = "svd-f7x3", feature = "svd-f730")))]
 define_ptr_type!(VtempCal110, 0x1FF0_F44E);
 


### PR DESCRIPTION
For some reason ST puts these registers at different locations on different devices.

ST publishes three different reference manuals: RM0385, RM0410, and RM0431.  The first two document the UID and FlashSize registers at the addresses used before this commit; the last has them at the newly added addresses.  That last reference manual is for the F7x2, F7x3, and F730 devices, so use these other addresses for those three types of device.